### PR TITLE
Update to leaflet-routing-machine 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "jsonp": "^0.2.0",
     "leaflet-control-geocoder": "^1.2.1",
-    "leaflet-routing-machine": "^2.4.0",
+    "leaflet-routing-machine": "^2.5.0",
     "leaflet.locatecontrol": "^0.44.0",
     "local-storage": "^1.4.2"
   }


### PR DESCRIPTION
Closes #127 (total distance is shown with fixed precision by default), also includes some minor performance tweaks that are noticable for very long routes and/or slow machines.
