### PR TITLE
Update to Leaflet 0.7.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>Open Source Routing Machine DEMO</title>
     <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
     <link rel="shortcut icon" href="favicon.ico" />
-    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css' />
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js'></script>
+    <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.css' />
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js'></script>
     <link rel="stylesheet" href="css/fonts.css" />
     <link href='css/site.css' rel='stylesheet' />
   </head>  


### PR DESCRIPTION
Use latest stable release. Among other things. fixes an annoying regression when zooming with newer versions of Chrome.
