### PR TITLE
Enable OSRM zoom parameter, shorten drag interval

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,9 @@ var control = L.Routing.control({
   language: viewOptions.language,
   showAlternatives: true,
   units: viewOptions.units,
-  serviceUrl: mapView.services[0].path
+  serviceUrl: mapView.services[0].path,
+  useZoomParameter: true,
+  routeDragInterval: 100
 }).addTo(map);
 var toolsControl = tools.control(control, L.extend({
   position: 'bottomleft',

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -29,7 +29,9 @@ module.exports = {
     geocodersClassName: 'osrm-directions-inputs',
     createGeocoder: createGeocoder,
     itineraryBuilder: 'osrm-directions-steps',
-    showAlternatives: true
+    showAlternatives: true,
+    useZoomParameter: true,
+    routeDragInterval: 100
   },
   popup: {
     removeButtonClass: 'osrm-directions-icon osrm-close-light-icon',


### PR DESCRIPTION
The LRM option `useZoomParameter` was specifically implemented for the OSRM frontend, because it was considered important by @TheMarex, but it seems it has been accidentally disabled in the current version (it's off by default in LRM because of legacy reasons).

Also, the interval between route calculations (`routeDragInterval`) when dragging markers was drastically shorter before, which makes the app feel snappier, which I've seen complaints about after the new frontend was shipped.
