### PR TITLE
Use lrm options for all options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,11 +111,11 @@ var plan = new ReversablePlan([], {
     });
     return marker;
   },
-  routeDragInterval: 100,
+  routeDragInterval: options.lrm.routeDragInterval,
   addWaypoints: true,
   waypointMode: 'snap',
   position: 'topright',
-  useZoomParameter: true,
+  useZoomParameter: options.lrm.useZoomParameter,
   reverseWaypoints: true,
   dragStyles: options.lrm.dragStyles,
   geocodersClassName: options.lrm.geocodersClassName,
@@ -143,7 +143,7 @@ plan.on('waypointgeocoded', function(e) {
 plan.createMarker = markerFactory(plan, options.popup);
 var control = L.Routing.control({
   plan: plan,
-  routeWhileDragging: true,
+  routeWhileDragging: options.lrm.routeWhileDragging,
   lineOptions: options.lrm.lineOptions,
   altLineOptions: options.lrm.altLineOptions,
   summaryTemplate: options.lrm.summaryTemplate,
@@ -151,11 +151,11 @@ var control = L.Routing.control({
   alternativeClassName: options.lrm.alternativeClassName,
   stepClassName: options.lrm.stepClassName,
   language: viewOptions.language,
-  showAlternatives: true,
+  showAlternatives: options.lrm.showAlternatives,
   units: viewOptions.units,
   serviceUrl: mapView.services[0].path,
-  useZoomParameter: true,
-  routeDragInterval: 100
+  useZoomParameter: options.lrm.useZoomParameter,
+  routeDragInterval: options.lrm.routeDragInterval
 }).addTo(map);
 var toolsControl = tools.control(control, L.extend({
   position: 'bottomleft',

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -22,6 +22,7 @@ module.exports = {
       {color: 'black', opacity: 0.35, weight: 9},
       {color: 'white', opacity: 0.8, weight: 7}
     ],
+    routeWhileDragging: true
     summaryTemplate: '<div class="osrm-directions-summary"><h2>{name}</h2><h3>{distance}, {time}</h3></div>',
     containerClassName: 'dark pad2',
     alternativeClassName: 'osrm-directions-instructions',


### PR DESCRIPTION
Just used the options from lrm_options and moved routeWhileDragging to lrm_options for clarity.
This way you can change the options more easily, because they are bundled in one place and you therefore only need to change one file.
Or was it intended to double hardcode them for some reason?
