### PR TITLE
Use osrm-backend 5.0.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The most common modifcation is to add your own OSRM endpoint. For this open `src
 ```
   services: [{
     label: 'Car (fastest)',
-    path: 'http://api-osrm-routed-patrick-develop.tilestream.net/viaroute'
+    path: 'http://api-osrm-routed-patrick-develop.tilestream.net/route/v1'
   }],
 
 ```

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "jsonp": "^0.2.0",
     "leaflet-control-geocoder": "^1.2.1",
-    "leaflet-routing-machine": "^2.6.2",
+    "leaflet-routing-machine": "^3.0.1",
     "leaflet.locatecontrol": "^0.44.0",
     "local-storage": "^1.4.2",
     "qs": "^6.1.0"

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   services: [{
     label: 'Car (fastest)',
-    path: 'https://router.project-osrm.org/viaroute'
+    path: 'https://router.project-osrm.org/route/v1'
   }],
   layer: [{
     'Mapbox Streets': streets,

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -31,7 +31,7 @@ module.exports = {
     createGeocoder: createGeocoder,
     itineraryBuilder: 'osrm-directions-steps',
     showAlternatives: true,
-    useZoomParameter: true,
+    useZoomParameter: false,
     routeDragInterval: 100
   },
   popup: {


### PR DESCRIPTION
This PR upgrades the `leaflet-routing-machine` to the latest version and changes the default value for 
`useZoomParameter` in order to show routes in the frontend with a osrm-backend v5.0.0+.

Furhtermore the url in the README is changed as well.
