### PR TITLE
Add option to make instructions sidebar collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This will start an auto-reloading webserver at http://localhost:9966
 
 ## Local OSRM instance
 
-The most common modifcation is to add your own OSRM endpoint. For this open `src/leaflet_options.js`:
+The most common modification is to add your own OSRM endpoint. For this open `src/leaflet_options.js`:
 
 ```
   services: [{

--- a/css/site.css
+++ b/css/site.css
@@ -158,6 +158,7 @@
   max-width: 340px;
   min-width: 200px;
   padding-right: 0px;
+  transition: 0.5s;
 }
 
 .leaflet-routing-container.dark {
@@ -277,6 +278,7 @@
   min-width: 200px;
   height: 95%;
   overflow: scroll;
+  transition: 0.5s;
 }
 
 /* OSRM + Leaflet toolbar icons */
@@ -849,5 +851,32 @@ td.distance {
 
 }
 
+.leaflet-routing-collapse-btn {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background-color: rgba(37, 72, 127, 0.74902);
+    width: 36px;
+    height: 36px;
+    display: flex;
+    cursor: pointer;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 18px;
+    justify-content:center;
+    align-items: center;
+    color: white;
+}
 
+.leaflet-routing-collapse-btn:after {
+    content: '\203a';
+}
 
+.leaflet-routing-container-hide .leaflet-routing-collapse-btn:after {
+    content: '\2039';
+}
+
+.leaflet-routing-container-hide.dark, .leaflet-routing-container-hide .leaflet-routing-alternatives-container {
+    margin-right: -340px !important;
+    transition: 0.5s;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,8 @@ var controlOptions = {
   units: mergedOptions.units,
   serviceUrl: leafletOptions.services[0].path,
   useZoomParameter: options.lrm.useZoomParameter,
-  routeDragInterval: options.lrm.routeDragInterval
+  routeDragInterval: options.lrm.routeDragInterval,
+  collapsible: options.lrm.collapsible
 };
 var router = (new L.Routing.OSRMv1(controlOptions));
 router._convertRouteOriginal = router._convertRoute;

--- a/src/lrm_options.js
+++ b/src/lrm_options.js
@@ -31,7 +31,8 @@ module.exports = {
     createGeocoder: createGeocoder,
     showAlternatives: true,
     useZoomParameter: false,
-    routeDragInterval: 200
+    routeDragInterval: 200,
+    collapsible: true
   },
   popup: {
     removeButtonClass: 'osrm-directions-icon osrm-close-light-icon',


### PR DESCRIPTION
This PR adds a new configuration options `collapsible` in `lrm_options.js`. Setting this option to true leads to a button being rendered that makes the instructions panel on the right collapse on click (and uncollapse with a second click).