### PR TITLE
Fix some language selection issues

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -424,6 +424,7 @@
    width: auto;
    text-align: justify;
    padding: 2px 4px;
+   z-index: 8;
 }
 
 .leaflet-osrm-tools-container div

--- a/src/tools.js
+++ b/src/tools.js
@@ -103,20 +103,20 @@ var Control = L.Control.extend({
   },
 
   _createLocalizationList: function(container) {
+    var _this = this;
     var localizationButton = L.DomUtil.create('span', this.options.localizationButtonClass + "-" + this._local.key, container);
     localizationButton.title = this._local['Select language'];
     L.DomEvent.on(localizationButton, 'click', function() { this.fire("languagechanged", {language: this._local.key}); }, this);
-    for (var key in this._languages)
-    {
-        if (key == this._local.key)
+    Object.keys(this._languages).forEach(function(key) {
+        if (key == _this._local.key)
         {
-            continue;
+            return;
         }
-        var button = L.DomUtil.create('span', this.options.localizationButtonClass + "-" + key + " leaflet-osrm-tools-hide", container);
-        button.title = this._languages[key];
+        var button = L.DomUtil.create('span', _this.options.localizationButtonClass + "-" + key + " leaflet-osrm-tools-hide", container);
+        button.title = _this._languages[key];
         var ev = {language: String(key)};
-        L.DomEvent.on(button, 'click', function() { this.fire("languagechanged", ev); }, this);
-    }
+        L.DomEvent.on(button, 'click', function() { _this.fire("languagechanged", ev); }, _this);
+    });
   },
 
   _openLocalizationList: function() {


### PR DESCRIPTION
This should fix two of the issues that are described in #212:
* Clicking on a language results in empty browser window (still happens for some languages, see below).
* Leaflet scale is in front of some languages, so they cannot be selected.

It *does not fix* the following problems:
* Not all flags match the language that gets selected when clicking the flag (they are missing in the CSS and the SVG).
* The selection of some languages results in an empty browser window (the `osrm-text-instructions` that are used (0.0.7) lack instructions for `es` and `sv`, and they throw an exception if a language they don't know is used).