### PR TITLE
Russian language selector

### DIFF
--- a/i18n/ru.js
+++ b/i18n/ru.js
@@ -1,0 +1,12 @@
+module.exports = {
+  name: 'Русский',
+  key: 'ru',
+  'Open in Debug Map': 'Открыть в отладочной карте',
+  'Open in Mapillary': 'Открыть в Mapillary',
+  'Open in editor': 'Открыть в редакторе',
+  'Open in JOSM': 'Открыть в редакторе JOSM',
+  'Select language': 'Выбрать язык',
+  'Start - press enter to drop marker': 'Начало - нажмите Enter, чтобы удалить маркер',
+  'End - press enter to drop marker': 'Конец - нажмите Enter, чтобы удалить маркер',
+  'Via point - press enter to drop marker': 'Промежуточная точка - нажмите Enter, чтобы удалить маркер'
+};

--- a/src/localization.js
+++ b/src/localization.js
@@ -5,6 +5,7 @@ var language_mapping = {
   de: require('../i18n/de'),
   es: require('../i18n/es'),
   fr: require('../i18n/fr'),
+  ru: require('../i18n/ru'),
   sv: require('../i18n/sv'),
   'zh-Hans': require('../i18n/zh-Hans')
 };


### PR DESCRIPTION
PR #215 with updated osrm-text-instructions@0.2.0 allows to enable Russian language selection on the frontend. Here are necessary changes to do this.