### PR TITLE
Adds Frontend Docker Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ This is the frontend served at https://map.project-osrm.org.
 This frontend builds heavily on top of [Leaflet Routing Machine](https://github.com/perliedman/leaflet-routing-machine).
 If you need a simple OSRM integration in your webpage, you should start from there.
 
+
+## Using Docker
+
+The easiest and quickest way to setup your own routing engine backend is to use Docker images we provide.
+We base [our Docker images](https://hub.docker.com/r/osrm/osrm-frontend/) on Alpine Linux and make sure they are as lightweight as possible.
+
+Serves the frontend at `http://localhost:9966` running queries against the routing engine backend:
+
+```
+docker run -p 9966:9966 osrm/osrm-frontend
+```
+
+Per default routing requests are made against the backend at `http://localhost:5000`.
+You can change the backend by using `-e BACKEND='http://localhost:5001'` in the `docker run` command.
+
+In case Docker complains about not being able to connect to the Docker daemon make sure you are in the `docker` group.
+
+```
+sudo usermod -aG docker $USER
+```
+
 ## Development
 
 Install dependencies via

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine:3.5
+
+ENV BACKEND='http://localhost:5000'
+
+RUN mkdir /src
+COPY . /src
+WORKDIR /src
+
+RUN apk add --no-cache sed nodejs && \
+    cd /src && \
+    sed -i "s|https://router.project-osrm.org|${BACKEND}|g" src/leaflet_options.js && \
+    sed -i "s|http://router.project-osrm.org|${BACKEND}|g" debug/index.html && \
+    npm install
+
+EXPOSE 9966
+CMD ["npm", "start"]

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# We've placed the Dockerfile under docker/ so that the generically named
+# hooks/ directory doesn't pollute the main directory.  Because we need to
+# COPY the source into the container, we need to use some -f gymnastics to
+# ensure that "COPY . /src" is referring to the repo root, not the directory
+# that contains the Dockerfile.
+# This script gets executed with a pwd of wherever the Dockerfile is.
+docker build -t $IMAGE_NAME -f Dockerfile ..


### PR DESCRIPTION
Frontend in a box. Spawn up frontend on `localhost:8080` via:

    docker run -p 8080:9966 osrm/osrm-frontend:latest

makes requests against `localhost:5000` by default (can be changed via `-e` env var).

cc @danpat 