### PR TITLE
Yet another modification to the addWaypoint function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,13 +182,14 @@ plan.on('waypointgeocoded', function(e) {
 });
 
 // add onClick event
-map.on('click', addWaypoint);
-function addWaypoint(e) {
+map.on('click', function (e){
+  addWaypoint(e.latlng);
+});
+function addWaypoint(waypoint) {
   var length = lrmControl.getWaypoints().filter(function(pnt) {
     return pnt.latLng;
   });
   length = length.length;
-  var waypoint = e.latlng;
   if (!length) {
     lrmControl.spliceWaypoints(0, 1, waypoint);
   } else {


### PR DESCRIPTION
Since the `addWaypoint` function deals with `waypoints`, it makes more sens to pass it a `waypoint `as an argument, not the click event.
IMO, this makes the code more cleaner.