### PR TITLE
Replace Array.find() with indexOf() for IE

### DIFF
--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -38,9 +38,8 @@ module.exports = function (language) {
       var classes = ['leaflet-routing-icon', 'lanes'];
       if (!l.valid) classes.push(['invalid']);
 
-      var indication = l.indications.find(function(e) {
-        return e === step.maneuver.modifier;
-      }) || l.indications[0];
+      // find maneuver modifier in indications or use first default
+      var indication = (l.indications.indexOf(step.maneuver.modifier) == -1) ? l.indications[0] : step.maneuver.modifier;
 
       var icon;
       switch (indication) {

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -38,8 +38,9 @@ module.exports = function (language) {
       var classes = ['leaflet-routing-icon', 'lanes'];
       if (!l.valid) classes.push(['invalid']);
 
-      // find maneuver modifier in indications or use first default
-      var indication = (l.indications.indexOf(step.maneuver.modifier) == -1) ? l.indications[0] : step.maneuver.modifier;
+      // check maneuver direction matches this lane one(s)
+      var maneuverIndication = l.indications.indexOf(step.maneuver.modifier);
+      var indication = (maneuverIndication === -1) ? l.indications[0] : step.maneuver.modifier;
 
       var icon;
       switch (indication) {
@@ -60,15 +61,21 @@ module.exports = function (language) {
       case 'uturn':
         icon = 'u-turn';
         break;
-      case 'straight':
-      case 'none':
+      //case 'straight':
+      //case 'none':
       default:
         icon = 'continue';
         break;
       }
       classes.push('leaflet-routing-icon-' + icon);
 
-      return L.DomUtil.create('span', classes.join(' '));
+      var span = L.DomUtil.create('span', classes.join(' '));
+      
+      // gray out lane icon if it's not for this maneuver
+      if (maneuverIndication === -1)
+        L.DomUtil.setOpacity(span, 0.5);
+      
+      return span;
     });
   }
 


### PR DESCRIPTION
Replace new [Array.find()](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/find) call with older [Array.indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) to avoid runtime exceptions in Internet Explorer.
![array_find_error](https://cloud.githubusercontent.com/assets/4529411/24999913/69eda996-2050-11e7-835f-11a8d825ad3b.png)

This issue could be reproduced with [this route example](http://map.project-osrm.org/?z=15&center=38.907131%2C-77.036991&loc=38.909736%2C-77.041798&loc=38.899183%2C-77.032356&hl=en&alt=0) opened in IE.