### PR TITLE
Fix sharp/slight left icon name misprint

### DIFF
--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -52,10 +52,10 @@ module.exports = function (language) {
         icon = 'bear-right';
         break;
       case 'left':
-      case 'slight left':
+      case 'sharp left':
         icon = 'turn-left';
         break
-      case 'sharp left':
+      case 'slight left':
         icon = 'bear-left';
         break;
       case 'uturn':

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -45,16 +45,20 @@ module.exports = function (language) {
       var icon;
       switch (indication) {
       case 'right':
-      case 'sharp right':
         icon = 'turn-right';
+        break;
+      case 'sharp right':
+        icon = 'sharp-right';
         break;
       case 'slight right':
         icon = 'bear-right';
         break;
       case 'left':
-      case 'sharp left':
         icon = 'turn-left';
-        break
+        break;
+      case 'sharp left':
+        icon = 'sharp-left';
+        break;
       case 'slight left':
         icon = 'bear-left';
         break;


### PR DESCRIPTION
Some misprint seems to be in sharp/slight left icon name assigning.