### PR TITLE
Replace BACKEND variable on run, not at build time.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /src
 
 RUN apk add --no-cache sed nodejs && \
     cd /src && \
-    sed -i "s|https://router.project-osrm.org|${BACKEND}|g" src/leaflet_options.js && \
-    sed -i "s|http://router.project-osrm.org|${BACKEND}|g" debug/index.html && \
     npm install
 
 EXPOSE 9966

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.js",
   "scripts": {
     "test": "eslint src/*js i18n/*.js",
-    "build": "browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
+    "replace": "if [ ! -z ${BACKEND+x} ]; then sed -i -e \"s|https://router.project-osrm.org|${BACKEND}|g\" src/leaflet_options.js && sed -i -e \"s|http://router.project-osrm.org|${BACKEND}|g\" debug/index.html ; fi",
+    "build": "npm run replace && browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
     "start-index": "budo src/index.js --serve=bundle.js --live -d | bistre",
     "start": "npm run build && npm run start-index",
     "prepub": "npm run build"


### PR DESCRIPTION
This changes how we update `src/leaflet_options.js` and `debug/index.html` to replace the URL queried by the frontend.  Updates are made at `docker run` time, not `docker build`, enabling easy swapping of the URL without needing to re-build the image.