### PR TITLE
Upgrade browserify and other dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "license": "ISC",
   "devDependencies": {
     "bistre": "^1.0.1",
-    "browserify": "^10.2.4",
-    "budo": "^4.1.0",
-    "uglify-js": "^2.4.24"
+    "browserify": "^14.3.0",
+    "budo": "^9.4.0",
+    "uglify-js": "^2.8.0"
   },
   "dependencies": {
     "jsonp": "^0.2.0",


### PR DESCRIPTION
Upgrade **browserify** to get fixed **ecstatic** to avoid TypeError('The header content contains invalid characters') for browsers with non-latin headers connected to local frontend:
```
_http_outgoing.js:360
    throw new TypeError('The header content contains invalid characters');
    ^

TypeError: The header content contains invalid characters
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:360:11)
    at serve (C:\Install\Garmin\GitHub\osrm-frontend\node_modules\ecstatic\lib\ecstatic.js:204:11)
    at C:\Install\Garmin\GitHub\osrm-frontend\node_modules\ecstatic\lib\ecstatic.js:134:11
    at FSReqWrap.oncomplete (fs.js:123:15)
```
Original issues:
- https://github.com/indexzero/http-server/issues/244
- https://github.com/angular/angular-phonecat/issues/303