### PR TITLE
Move browserify & uglifyjs into separate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,19 @@ Install dependencies via
 npm install
 ```
 
-Then compile the assets and start a server with
+Then compile assets and start the local server with
 
 ```bash
 npm start
 ```
 
+On Windows with no Unix tools installed (`bash`, `sed`, `cp`) the server could be started with two other commands
+executed by `npm start` internally:
+
+```bash
+npm run compile
+npm run start-index
+```
 
 ## Changing Backends
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "frontend interface for project osrm",
   "main": "src/index.js",
   "scripts": {
-    "test": "eslint src/*js i18n/*.js",
+    "test": "eslint src/*.js i18n/*.js",
     "replace": "node ./scripts/replace.js",
-    "build": "npm run replace && browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
+    "compile": "browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js",
+    "build": "npm run replace && npm run compile && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
     "start-index": "budo src/index.js --serve=bundle.js --live -d | bistre",
     "start": "npm run build && npm run start-index",
     "prepub": "npm run build"


### PR DESCRIPTION
Starting frontend locally on Windows became much harder after BACKEND fix (#237). This commit proposes to move browserify calling into separate `package.json` script and allows Windows users to start frontend with two following commands with no `package.json` patching (#219):

```
npm run compile
npm run start-index
```
instead of `npm start`.