### PR TITLE
Customize Options using environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "eslint src/*js i18n/*.js",
-    "replace": "if [ ! -z ${BACKEND+x} ]; then sed -i -e \"s|https://router.project-osrm.org|${BACKEND}|g\" src/leaflet_options.js && sed -i -e \"s|http://router.project-osrm.org|${BACKEND}|g\" debug/index.html ; fi",
+    "replace": "node ./scripts/replace.js",
     "build": "npm run replace && browserify -d src/index.js -s osrm > bundle.raw.js && uglifyjs bundle.raw.js -c -m --source-map=bundle.js.map -o bundle.js && cp node_modules/leaflet/dist/leaflet.css css/leaflet.css",
     "start-index": "budo src/index.js --serve=bundle.js --live -d | bistre",
     "start": "npm run build && npm run start-index",

--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+// Define filepaths
+const leafletOptions = path.join(__dirname, '..', 'src', 'leaflet_options.js')
+const debug = path.join(__dirname, '..', 'debug', 'index.html')
+
+// Read & Replace options
+for (const filepath of [leafletOptions, debug]) {
+  let options = fs.readFileSync(filepath, 'utf8')
+
+  // Define Environment variables
+  const ZOOM = process.env.ZOOM
+  const LABEL = process.env.LABEL
+  const CENTER = process.env.CENTER
+  const BACKEND = process.env.BACKEND
+  const LANGUAGE = process.env.LANGUAGE
+
+  // Edit Leaflet Options
+  if (BACKEND) options = options.replace(/http[s]?:\/\/router\.project-osrm\.org/, BACKEND)
+  if (LABEL) options = options.replace('Car (fastest)', LABEL)
+  if (ZOOM) options = options.replace('zoom: 13', `zoom: ${ZOOM}`)
+  if (LANGUAGE) options = options.replace(`language: 'en'`, `language: '${LANGUAGE}'`)
+  if (CENTER) {
+    const [lat, lng] = CENTER.split(/[, ]+/)
+    const lnglat = [lng, lat].join(',')
+    const latlng = [lat, lng].join(',')
+
+    // Mapbox uses LngLat
+    if (options.match('-122.4536, 37.796')) options = options.replace('-122.4536, 37.796', lnglat)
+    // Leaflet uses LatLng
+    else options = options.replace('38.8995, -77.0269', latlng)
+  }
+
+  // Save Leaflet Options
+  fs.writeFileSync(filepath, options)
+}


### PR DESCRIPTION
Allows more customization from Environment variables defined by Docker or local deployment.

```dockerfile
ENV BACKEND='http://localhost:5000'
ENV CENTER='38.8995,-77.0269'
ENV ZOOM='13'
ENV LANGUAGE='en'
ENV LABEL='Car (fastest)'
```