### PR TITLE
Update links.js

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -61,7 +61,7 @@ function parseLink(link) {
     options = {},
     k;
   try {
-    parsedValues.zoom = _parseInteger(q.z);
+    parsedValues.zoom = q.z && _parseInteger(q.z);
     parsedValues.center = q.center && _parseCoord(q.center);
     parsedValues.waypoints = q.loc && q.loc.filter(function(loc) { return loc != ""; }).map(_parseCoord).map(
       function(coord) {

--- a/src/links.js
+++ b/src/links.js
@@ -55,6 +55,7 @@ function formatLink(options) {
 }
 
 function parseLink(link) {
+  if (!link) return {}
   var q = qs.parse(link),
     parsedValues = {},
     options = {},

--- a/src/links.js
+++ b/src/links.js
@@ -55,7 +55,7 @@ function formatLink(options) {
 }
 
 function parseLink(link) {
-  if (!link) return {}
+  if (!link) return {};
   var q = qs.parse(link),
     parsedValues = {},
     options = {},

--- a/src/links.js
+++ b/src/links.js
@@ -61,7 +61,7 @@ function parseLink(link) {
     options = {},
     k;
   try {
-    parsedValues.zoom = q.z && _parseInteger(q.z);
+    if (q.z !== undefined && q.z !== null) parsedValues.zoom = _parseInteger(q.z);
     parsedValues.center = q.center && _parseCoord(q.center);
     parsedValues.waypoints = q.loc && q.loc.filter(function(loc) { return loc != ""; }).map(_parseCoord).map(
       function(coord) {


### PR DESCRIPTION
Ref: https://github.com/Project-OSRM/osrm-frontend/issues/249

Seems like when you refresh the page with an empty URL path the warning message shows up.

http://localhost:9966/

However whenever the URL has all the parameters then the warning doesn't show up.

http://localhost:9966/?z=13&center=38.887626%2C-76.996307&hl=en&alt=0

When `parseLink(link)` was passing `undefined` it was getting caught in the exception.

Looks like the **warning** message came from a commit a year ago https://github.com/Project-OSRM/osrm-frontend/commit/709b20da5fb6be103b973b24f3182bea167db531.

> FYI: Including an entire code block in a Try/Catch is a bad idea.
> https://github.com/Project-OSRM/osrm-frontend/blob/gh-pages/src/links.js#L62-L77