### PR TITLE
Define default values for environment variables

### DIFF
--- a/scripts/replace.js
+++ b/scripts/replace.js
@@ -14,11 +14,11 @@ for (const filepath of [leafletOptions, debug]) {
   let options = fs.readFileSync(filepath, 'utf8')
 
   // Define Environment variables
-  const ZOOM = process.env.ZOOM
-  const LABEL = process.env.LABEL
-  const CENTER = process.env.CENTER
-  const BACKEND = process.env.BACKEND
-  const LANGUAGE = process.env.LANGUAGE
+  const ZOOM = process.env.ZOOM || 13
+  const LABEL = process.env.LABEL || 'Car (fastest)'
+  const CENTER = process.env.CENTER || '38.8995, -77.0269'
+  const BACKEND = process.env.BACKEND || 'https://router.project-osrm.org'
+  const LANGUAGE = process.env.LANGUAGE || 'en'
 
   // Edit Leaflet Options
   if (BACKEND) options = options.replace(/http[s]?:\/\/router\.project-osrm\.org/, BACKEND)


### PR DESCRIPTION
Looks like this would solve https://github.com/Project-OSRM/osrm-frontend/issues/249#issuecomment-311671357.

@daniel-j-h can you try this? I can't replicate the error on my environment.

I'm sure there's a more elegant way we can have configurable variables instead of using `.replace(before, after)`.