### PR TITLE
Migrate to osrm-text-instructions 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "leaflet-routing-machine": "~3.1.0",
     "leaflet.locatecontrol": "^0.44.0",
     "local-storage": "^1.4.2",
-    "osrm-text-instructions": "0.5.1",
+    "osrm-text-instructions": "~0.9.0",
     "qs": "^6.1.0"
   }
 }

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -6,13 +6,14 @@ module.exports = function (language) {
   var osrmTextInstructionsOptions = {
     hooks: {
       tokenizedInstruction: function (instruction) {
-        // enclose {way_name}, {rotary_name} and {destination} vars with <b>..</b>
+        // enclose {way_name}, {rotary_name}, {destination} and {exit} vars with <b>..</b>
         // also support optional grammar or other var option after colon like {way_name:accusative}
         return instruction.replace(/\{(\w+):?\w*\}/g, function (token, tag) {
           switch (tag) {
           case 'way_name':
           case 'rotary_name':
           case 'destination':
+          case 'exit':
             return '<b>' + token + '</b>';
           }
           return token;
@@ -20,7 +21,7 @@ module.exports = function (language) {
       }
     }
   };
-  var osrmTextInstructions = require('osrm-text-instructions')('v5', language, osrmTextInstructionsOptions);
+  var osrmTextInstructions = require('osrm-text-instructions')('v5', osrmTextInstructionsOptions);
 
   function stepToText(step) {
     try {


### PR DESCRIPTION
Update for changed osrm-text-instructions v0.5 API to restore broken names highlighting introduced in #223.
New {exit} names are also highlighted now.