### PR TITLE
Make use of local routing service

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 # Enables customized options using environment variables
-ENV OSRM_BACKEND='http://router.project-osrm.org'
+ENV OSRM_BACKEND='http://localhost:5000'
 ENV OSRM_CENTER='38.8995,-77.0269'
 ENV OSRM_ZOOM='13'
 ENV OSRM_LANGUAGE='en'


### PR DESCRIPTION
Change the routing backend server from the official server to the local instance to match the quick starter guide (https://github.com/Project-OSRM/osrm-backend#using-docker). This was accidentally (?) changed in this commit (a9b7e5381a74260cdaf5237c6d4cc4c2bb6e7bfc) without given reason.