### PR TITLE
Update OSRM Text Instructions to 0.11.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "leaflet-routing-machine": "~3.1.0",
     "leaflet.locatecontrol": "~0.44.0",
     "local-storage": "^1.4.2",
-    "osrm-text-instructions": "~0.10.0",
+    "osrm-text-instructions": "~0.11.0",
     "qs": "^6.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "leaflet-routing-machine": "~3.1.0",
     "leaflet.locatecontrol": "~0.44.0",
     "local-storage": "^1.4.2",
-    "osrm-text-instructions": "~0.9.0",
+    "osrm-text-instructions": "~0.10.0",
     "qs": "^6.1.0"
   }
 }


### PR DESCRIPTION
Update OSRM Text Instructions package dependency to 0.10.x (0.10.6 currently) with many improvements and fixes since 0.9.0.

It will be great if somebody from maintainers could also update bundles to refresh running demo server.