### PR TITLE
Fix link parsing for waypoints

### DIFF
--- a/src/links.js
+++ b/src/links.js
@@ -63,11 +63,21 @@ function parseLink(link) {
   try {
     if (q.z !== undefined && q.z !== null) parsedValues.zoom = _parseInteger(q.z);
     parsedValues.center = q.center && _parseCoord(q.center);
-    parsedValues.waypoints = q.loc && q.loc.filter(function(loc) { return loc != ""; }).map(_parseCoord).map(
-      function(coord) {
-        return L.Routing.waypoint(coord);
+    if (q.loc) {
+      if (q.loc.constructor === Array) {
+        // more than one loc is given
+        parsedValues.waypoints = q.loc.filter(function (loc) {
+            return loc != "";
+        }).map(_parseCoord).map(
+            function (coord) {
+                return L.Routing.waypoint(coord);
+            }
+        );
+      } else if (q.loc.constructor === String) {
+        // exactly one loc is given
+        parsedValues.waypoints = [L.Routing.waypoint(_parseCoord(q.loc))];
       }
-    );
+    }
     parsedValues.language = q.hl;
     parsedValues.alternative = q.alt;
     parsedValues.units = q.df;


### PR DESCRIPTION
Previously, waypoint parsing from links only worked iff more than one
`loc` was given in the link because qs parses several locs to an array
but only one loc to a string. Therefore we check if `q.loc` is an array
or a string and adapt the waypoint parsing accordingly.

Fixes #194