### PR TITLE
Fix formatToken() callback to process only non-empty tokens

### DIFF
--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -14,9 +14,12 @@ module.exports = function (language) {
           switch (token) {
             case 'way_name':
             case 'rotary_name':
+            case 'waypoint_name':
             case 'destination':
             case 'exit':
-              return '<b>' + value + '</b>';
+              // Exclude prepending articles/prepositions from French names
+              return value.replace(/^((à )|(au )|(aux )|(le rond-point ))?((d’)|(de )|(des )|(du ))?((l’)|(la )|(le )|(les ))?/,
+                '$&<b>') + '</b>';
             }
           }
           return value;

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -10,13 +10,14 @@ module.exports = function (language) {
       return osrmTextInstructions.compile(language, step, {
         formatToken : function(token, value) {
         // enclose {way_name}, {rotary_name}, {destination} and {exit} vars with <b>..</b>
-        switch (token) {
-          case 'name':
-          case 'way_name':
-          case 'rotary_name':
-          case 'destination':
-          case 'exit':
-            return '<b>' + value + '</b>';
+        if (value) {
+          switch (token) {
+            case 'way_name':
+            case 'rotary_name':
+            case 'destination':
+            case 'exit':
+              return '<b>' + value + '</b>';
+            }
           }
           return value;
         }


### PR DESCRIPTION
And also to don't handle 'name' tokens so it's called before final instruction text formatting and grammar rules applying.
Please look at route steps before this fix:
![osrm-no-grammar](https://user-images.githubusercontent.com/4529411/36658115-1199d388-1ac7-11e8-97d8-240ce0d3f919.png)
And after (grammar rules restored; no name roads kept original):
![osrm-fixed-grammar](https://user-images.githubusercontent.com/4529411/36658169-462644f6-1ac7-11e8-9c1b-5e4d72ec30df.png)

