### PR TITLE
Fix margin of LRM control buttons

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -206,8 +206,9 @@
   background-color: rgba(37,72,127, 0.75);
   transition: background-color 0.2s ease;
   border: 0px;
-  border-radius: 5px;
-  margin-top: -3px;
+  border-radius: 0 0 5px 5px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   margin-right: 0px;
   color: white;
 }


### PR DESCRIPTION
The margin of the LRM inverse and add point button was set to `-3px`, which is visible behind the transparent input field of the to-filed.
![screen shot 2018-03-01 at 13 35 14](https://user-images.githubusercontent.com/11087340/36845127-c611aa08-1d55-11e8-9176-64e7c9df071d.png)

This PR should fix it like this:
![screen shot 2018-03-01 at 13 42 38](https://user-images.githubusercontent.com/11087340/36845300-720608d6-1d56-11e8-8064-1f4a30a41e0b.png)

