### PR TITLE
Graying out invalid lane icons with corrected style

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -584,7 +584,7 @@ td.distance {
 }
 
 .leaflet-routing-icon.lanes.invalid {
-    filter: invert(50%);
+    opacity: 0.5;
 }
 
 .leaflet-routing-alt-minimized .leaflet-routing-icon {

--- a/src/itinerary_builder.js
+++ b/src/itinerary_builder.js
@@ -88,13 +88,7 @@ module.exports = function (language) {
       }
       classes.push('leaflet-routing-icon-' + icon);
 
-      var span = L.DomUtil.create('span', classes.join(' '));
-
-      // gray out lane icon if it's not for this maneuver
-      if (maneuverIndication === -1)
-        L.DomUtil.setOpacity(span, 0.5);
-
-      return span;
+      return L.DomUtil.create('span', classes.join(' '));
     });
   }
 


### PR DESCRIPTION
Manual hack to grey out invalid lane icons is replaced with CSS style correction (compatible with IE11), see  screenshot in [#279 issue comment](https://github.com/Project-OSRM/osrm-frontend/issues/279#issuecomment-400351624).