### PR TITLE
osrm-text-instructions@0.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "leaflet-routing-machine": "~3.1.0",
     "leaflet.locatecontrol": "~0.44.0",
     "local-storage": "^1.4.2",
-    "osrm-text-instructions": "~0.11.0",
+    "osrm-text-instructions": "~0.13.0",
     "qs": "^6.1.0"
   }
 }


### PR DESCRIPTION
Switch to osrm-text-instructions 0.13.*

It would be good if dependent #271 and #284 will be merged before too.