### PR TITLE
chore: add weekly dependency update workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,48 @@
+name: Dependabot Updates
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly on Sunday at 00:00 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update dependencies
+        run: npm update
+
+      - name: Rebuild after update
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if ! git diff --quiet; then
+            git add -A
+            git commit -m "chore: update dependencies"
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically updates npm dependencies on a weekly schedule.

**Changes:**
- Creates `.github/workflows/dependabot.yml`
- Runs every Sunday at 00:00 UTC
- Updates all npm dependencies with `npm update`
- Verifies updates don't break the build
- Auto-commits changes with Conventional Commits message