### PR TITLE
feat: fix mode selector click behavior on Chrome

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -357,9 +357,9 @@
     padding-left: 6px;
     padding-right: 6px;
     cursor: pointer;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
+    appearance: auto;
+    -moz-appearance: auto;
+    -webkit-appearance: auto;
     vertical-align: middle;
     font-size: 13px;
     line-height: 24px;
@@ -389,9 +389,9 @@
     padding-left: 6px;
     padding-right: 6px;
     cursor: pointer;
-    appearance: none;
-    -moz-appearance: none;
-    -webkit-appearance: none;
+    appearance: auto;
+    -moz-appearance: auto;
+    -webkit-appearance: auto;
     vertical-align: top;
     font-size: 13px;
     line-height: 32px;

--- a/src/index.js
+++ b/src/index.js
@@ -291,9 +291,6 @@ var state = state(map, lrmControl, toolsControl, modeSelector, mergedOptions);
       }
     });
 
-    L.DomEvent.on(modeSelector.select, 'mouseup', function(event) {
-      clearProfileSelectorSelection(event.target);
-    });
   }
 }());
 

--- a/src/mode_selector.js
+++ b/src/mode_selector.js
@@ -15,6 +15,10 @@ function createModeSelector(localization, profiles) {
   var container = L.DomUtil.create('span', 'leaflet-osrm-mode-selector');
   var profileSelect = L.DomUtil.create('select', 'osrm-profile-chooser', container);
   profileSelect.setAttribute('title', localization['Select profile'] || 'Select profile');
+  // Allow opening the native select dropdown while preventing events from bubbling to parent map controls
+  L.DomEvent.on(profileSelect, 'mousedown', L.DomEvent.stopPropagation);
+  L.DomEvent.on(profileSelect, 'click', L.DomEvent.stopPropagation);
+  L.DomEvent.on(profileSelect, 'touchstart', L.DomEvent.stopPropagation);
 
   profiles.forEach(function(profile, index) {
     var option = L.DomUtil.create('option', 'fill-osrm', profileSelect);


### PR DESCRIPTION
Allow mode selector to open with a single click in Chrome, prevent parent map handlers from immediately closing it, and restore native select arrows. Includes event stopPropagation on the select and appearance:auto CSS.

fixes #428 