### PR TITLE
fix: accept single-string and array of string URLs in OSRM_MODES (fixes #427)

### DIFF
--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -101,7 +101,9 @@ function parseModes() {
       }
 
       // If modes is an array of strings and contains multiple entries, map them to Mode 1/2/..
-      if (Array.isArray(modes) && modes.length > 1 && modes.every(function(m) { return typeof m === 'string'; })) {
+      if (Array.isArray(modes) && modes.length > 1 && modes.every(function(m) {
+        return typeof m === 'string'; 
+      })) {
         var profileNames = ['driving', 'bike', 'foot'];
         return modes.map(function(url, index) {
           return {

--- a/src/leaflet_options.js
+++ b/src/leaflet_options.js
@@ -100,6 +100,29 @@ function parseModes() {
         modes = JSON.parse(modesValue);
       }
 
+      // If modes is an array of strings and contains multiple entries, map them to Mode 1/2/..
+      if (Array.isArray(modes) && modes.length > 1 && modes.every(function(m) { return typeof m === 'string'; })) {
+        var profileNames = ['driving', 'bike', 'foot'];
+        return modes.map(function(url, index) {
+          return {
+            name: 'Mode ' + (index + 1),
+            url: url,
+            profile: profileNames[index] || 'driving'
+          };
+        });
+      }
+
+      // Special-case: accept a single-string array as the legacy single backend URL
+      if (Array.isArray(modes) && modes.length === 1 && typeof modes[0] === 'string') {
+        return [
+          {
+            name: 'default',
+            url: modes[0],
+            profile: 'driving'
+          }
+        ];
+      }
+
       if (Array.isArray(modes) && modes.length > 0) {
         // Keep freely named user-facing modes while assigning known internal routing profiles.
         return modes.map(function(mode, index) {

--- a/test/leaflet_options.test.js
+++ b/test/leaflet_options.test.js
@@ -326,6 +326,38 @@ describe('leaflet_options — runtime configuration overrides', () => {
       delete global.window;
     });
 
+    test('accepts single-string URL in a JSON array as a single mode', () => {
+      const modesJSON = JSON.stringify(['http://custom:5000']);
+      global.window = {
+        osrmConfig: {
+          OSRM_ENVIRONMENT: 'docker',
+          OSRM_MODES: modesJSON
+        }
+      };
+      const leafletOptions = require('../src/leaflet_options');
+      expect(leafletOptions.services.length).toBe(1);
+      expect(leafletOptions.services[0].path).toContain('custom:5000');
+      expect(leafletOptions.services[0].label).toBe('default');
+      delete global.window;
+    });
+
+    test('accepts array of string URLs as multiple modes', () => {
+      const modesJSON = JSON.stringify(['http://custom:5000','http://custom:5001']);
+      global.window = {
+        osrmConfig: {
+          OSRM_ENVIRONMENT: 'docker',
+          OSRM_MODES: modesJSON
+        }
+      };
+      const leafletOptions = require('../src/leaflet_options');
+      expect(leafletOptions.services.length).toBe(2);
+      expect(leafletOptions.services[0].path).toContain('custom:5000');
+      expect(leafletOptions.services[1].path).toContain('custom:5001');
+      expect(leafletOptions.services[0].label).toBe('Mode 1');
+      expect(leafletOptions.services[1].label).toBe('Mode 2');
+      delete global.window;
+    });
+
     test('OSRM_MODES takes priority over OSRM_BACKEND', () => {
       const modesJSON = JSON.stringify([
         { name: 'Custom', url: 'http://custom:5000' }


### PR DESCRIPTION
This PR makes OSRM_MODES parsing more flexible:

- Accept a JSON array with a single string URL and treat it as the legacy single backend named "default".
- Accept a JSON array of strings and map each URL to a Mode N entry (Mode 1, Mode 2...).
- Adds tests covering both scenarios.

Closes #427

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>