### PR TITLE
fix: respect browser language preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
         // In all other cases (dev, browser), leave it undefined to use public services
         OSRM_CENTER: '38.8995,-77.0269',
         OSRM_ZOOM: 13,
-        OSRM_LANGUAGE: 'en',
         OSRM_DEFAULT_LAYER: 'streets'
         // OSRM_BACKEND and OSRM_MODES will be set by config.json if available
       };

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ var controlOptions = {
   containerClassName: options.lrm.containerClassName,
   alternativeClassName: options.lrm.alternativeClassName,
   stepClassName: options.lrm.stepClassName,
-  language: 'en', // we are injecting own translations via osrm-text-instructions
+  language: mergedOptions.language, // we are injecting own translations via osrm-text-instructions
   showAlternatives: options.lrm.showAlternatives,
   units: mergedOptions.units,
   serviceUrl: leafletOptions.services[0].path,


### PR DESCRIPTION
Remove default OSRM_LANGUAGE from index.html so browser/URL-configured language is used when available.

This allows Accept-Language detection to select the appropriate localization when no runtime config sets the language.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>