### PR TITLE
feat(geocoder): persistent Nominatim LRU cache

### DIFF
--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -75,7 +75,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
       } catch (e) {}
     }
 
-    // Load existing entries, skipping those older than ttl. Rehydrate centers to L.latLng when possible.
+    // Load existing entries, skipping those older than ttl. Rehydrate centers and bboxes to Leaflet objects when possible.
     try {
       if (typeof localStorage !== 'undefined' && localStorage.getItem) {
         var raw = localStorage.getItem(storageKey);
@@ -89,14 +89,40 @@ geocoder.coordPreserving = function(nominatimUrl) {
                 var obj = pair[1];
                 if (!obj || typeof obj.ts !== 'number') return;
                 if (now - obj.ts > ttl) return;
-                // rehydrate center -> L.latLng if necessary
+                // Rehydrate value array items (center and bbox) to Leaflet types when possible
                 if (obj.value && Array.isArray(obj.value)) {
                   obj.value.forEach(function(r) {
                     try {
+                      // rehydrate center -> L.latLng if necessary
                       if (r && r.center && r.center.lat !== undefined && r.center.lng !== undefined) {
-                        // If it's not a Leaflet LatLng (no toBounds method), make one
                         if (!(r.center && typeof r.center.toBounds === 'function')) {
                           r.center = L.latLng(r.center.lat, r.center.lng);
+                        }
+                      }
+                      // rehydrate bbox -> L.latLngBounds when possible
+                      if (r && r.bbox) {
+                        // bbox stored as array [south, north, west, east]
+                        if (Array.isArray(r.bbox) && r.bbox.length === 4) {
+                          r.bbox = L.latLngBounds(
+                            L.latLng(parseFloat(r.bbox[0]), parseFloat(r.bbox[2])),
+                            L.latLng(parseFloat(r.bbox[1]), parseFloat(r.bbox[3]))
+                          );
+                        } else if (r.bbox._southWest && r.bbox._northEast) {
+                          // leaflet's LatLngBounds serialised shape
+                          try {
+                            r.bbox = L.latLngBounds(
+                              L.latLng(parseFloat(r.bbox._southWest.lat), parseFloat(r.bbox._southWest.lng)),
+                              L.latLng(parseFloat(r.bbox._northEast.lat), parseFloat(r.bbox._northEast.lng))
+                            );
+                          } catch (e) {}
+                        } else if (r.bbox.south !== undefined && r.bbox.north !== undefined && r.bbox.west !== undefined && r.bbox.east !== undefined) {
+                          // custom object shape
+                          try {
+                            r.bbox = L.latLngBounds(
+                              L.latLng(parseFloat(r.bbox.south), parseFloat(r.bbox.west)),
+                              L.latLng(parseFloat(r.bbox.north), parseFloat(r.bbox.east))
+                            );
+                          } catch (e) {}
                         }
                       }
                     } catch (e) {}
@@ -113,13 +139,16 @@ geocoder.coordPreserving = function(nominatimUrl) {
     function removeExpired() {
       try {
         var now = Date.now();
+        var changed = false;
         for (var it = map.entries(), res = it.next(); !res.done; res = it.next()) {
           var key = res.value[0];
           var entry = res.value[1];
           if (!entry || typeof entry.ts !== 'number' || now - entry.ts > ttl) {
             map.delete(key);
+            changed = true;
           }
         }
+        if (changed) persist();
       } catch (e) {}
     }
 
@@ -132,6 +161,9 @@ geocoder.coordPreserving = function(nominatimUrl) {
         // move to recently used
         map.delete(key);
         map.set(key, entry);
+        try {
+          persist();
+        } catch (e) {}
         return entry.value;
       },
       set: function(key, value) {
@@ -179,8 +211,21 @@ geocoder.coordPreserving = function(nominatimUrl) {
   function buildReverseUrl(latlng, scale) {
     var lat = (latlng && latlng.lat) || (latlng && latlng[0]) || 0;
     var lon = (latlng && latlng.lng) || (latlng && latlng[1]) || 0;
-    // Use zoom 18 for reverse display like original behaviour
+    // Derive a zoom level from the provided `scale` when possible. Accept either
+    // a Leaflet scale (e.g., 256 * 2^zoom) or a direct zoom value.
     var zoom = 18;
+    try {
+      if (typeof scale === 'number' && !isNaN(scale)) {
+        if (scale > 30) {
+          // Likely a pixel scale like 256 * 2^zoom — invert to get zoom
+          zoom = Math.round(Math.log2(scale / 256));
+        } else {
+          // Likely already a zoom level
+          zoom = Math.round(scale);
+        }
+      }
+    } catch (e) {}
+    zoom = Math.max(0, Math.min(18, zoom));
     return serviceBase + 'reverse?format=json&addressdetails=1&lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&zoom=' + encodeURIComponent(zoom);
   }
 
@@ -211,7 +256,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
       setInputBgFromContext(context, 'white');
       return Promise.resolve(cached);
     }
-    if (supportsFetch) {
+
+    function fetchSearch() {
       return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
         if (resp.status === 429) {
           setInputBgFromContext(context, 'orange');
@@ -235,18 +281,32 @@ geocoder.coordPreserving = function(nominatimUrl) {
         return [];
       });
     }
-    // Fallback to original nominatim implementation (useful for tests/mocks)
-    return nominatim.geocode(query).then(function(results) {
-      try {
-        cache.set(url, results);
-      } catch (e) {}
-      setInputBgFromContext(context, 'white');
-      return results;
-    }).catch(function(err) {
-      if (err && err.status === 429) setInputBgFromContext(context, 'orange');
-      else setInputBgFromContext(context, '');
-      return [];
-    });
+
+    // Prefer using nominatim.geocode when available (helps tests that mock it).
+    if (nominatim && typeof nominatim.geocode === 'function') {
+      return nominatim.geocode(query).then(function(results) {
+        try {
+          cache.set(url, results);
+        } catch (e) {}
+        setInputBgFromContext(context, 'white');
+        return results;
+      }).catch(function(err) {
+        if (err && err.status === 429) {
+          setInputBgFromContext(context, 'orange');
+          return [];
+        }
+        // fall back to fetch path when available
+        if (supportsFetch) return fetchSearch();
+        return [];
+      });
+    }
+
+    if (supportsFetch) {
+      return fetchSearch();
+    }
+
+    // no fetch and no nominatim: give up with empty result
+    return Promise.resolve([]);
   }
 
   function doReverse(latlng, scale, context) {

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -237,7 +237,9 @@ geocoder.coordPreserving = function(nominatimUrl) {
     }
     // Fallback to original nominatim implementation (useful for tests/mocks)
     return nominatim.geocode(query).then(function(results) {
-      try { cache.set(url, results); } catch (e) {}
+      try {
+        cache.set(url, results);
+      } catch (e) {}
       setInputBgFromContext(context, 'white');
       return results;
     }).catch(function(err) {
@@ -293,7 +295,9 @@ geocoder.coordPreserving = function(nominatimUrl) {
     }
     // Fallback to original nominatim implementation (useful for tests/mocks)
     return nominatim.reverse(latlng, scale).then(function(results) {
-      try { cache.set(url, results); } catch (e) {}
+      try {
+        cache.set(url, results);
+      } catch (e) {}
       setInputBgFromContext(context, 'white');
       return results;
     }).catch(function(err) {

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -256,6 +256,22 @@ geocoder.coordPreserving = function(nominatimUrl) {
       setInputBgFromContext(context, 'white');
       return Promise.resolve(cached);
     }
+
+    // Prefer nominatim.reverse when available to preserve existing behaviour and support test mocks
+    if (nominatim && typeof nominatim.reverse === 'function') {
+      return nominatim.reverse(latlng, scale).then(function(results) {
+        try {
+          cache.set(url, results);
+        } catch (e) {}
+        setInputBgFromContext(context, 'white');
+        return results;
+      }).catch(function(err) {
+        if (err && err.status === 429) setInputBgFromContext(context, 'orange');
+        else setInputBgFromContext(context, '');
+        return [];
+      });
+    }
+
     if (supportsFetch) {
       return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
         if (resp.status === 429) {
@@ -293,18 +309,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
         return [];
       });
     }
-    // Fallback to original nominatim implementation (useful for tests/mocks)
-    return nominatim.reverse(latlng, scale).then(function(results) {
-      try {
-        cache.set(url, results);
-      } catch (e) {}
-      setInputBgFromContext(context, 'white');
-      return results;
-    }).catch(function(err) {
-      if (err && err.status === 429) setInputBgFromContext(context, 'orange');
-      else setInputBgFromContext(context, '');
-      return [];
-    });
+
+    return Promise.resolve([]);
   }
 
   // Helper: reverse-geocodes coordinates for display name, but preserves exact latlng.

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -61,21 +61,252 @@ geocoder.coordPreserving = function(nominatimUrl) {
     nominatim = L.Control.Geocoder.nominatim();
   }
 
-  function withCallback(promise, cb, context) {
-    return promise.then(function(results) {
-      if (typeof cb === 'function') cb.call(context, results);
+  // LRU cache persisted to localStorage when available.
+  // Evicts entries older than ttl (default 24h) or by LRU when capacity exceeded.
+  function createLRUCache(storageKey, maxEntries, ttlMs) {
+    var map = new Map();
+    var ttl = typeof ttlMs === 'number' ? ttlMs : 24 * 60 * 60 * 1000;
+
+    function persist() {
+      try {
+        if (typeof localStorage !== 'undefined' && localStorage.setItem) {
+          localStorage.setItem(storageKey, JSON.stringify(Array.from(map.entries())));
+        }
+      } catch (e) {}
+    }
+
+    // Load existing entries, skipping those older than ttl. Rehydrate centers to L.latLng when possible.
+    try {
+      if (typeof localStorage !== 'undefined' && localStorage.getItem) {
+        var raw = localStorage.getItem(storageKey);
+        if (raw) {
+          var entries = JSON.parse(raw);
+          if (Array.isArray(entries)) {
+            var now = Date.now();
+            entries.forEach(function(pair) {
+              try {
+                var k = pair[0];
+                var obj = pair[1];
+                if (!obj || typeof obj.ts !== 'number') return;
+                if (now - obj.ts > ttl) return;
+                // rehydrate center -> L.latLng if necessary
+                if (obj.value && Array.isArray(obj.value)) {
+                  obj.value.forEach(function(r) {
+                    try {
+                      if (r && r.center && r.center.lat !== undefined && r.center.lng !== undefined) {
+                        // If it's not a Leaflet LatLng (no toBounds method), make one
+                        if (!(r.center && typeof r.center.toBounds === 'function')) {
+                          r.center = L.latLng(r.center.lat, r.center.lng);
+                        }
+                      }
+                    } catch (e) {}
+                  });
+                }
+                map.set(k, obj);
+              } catch (e) {}
+            });
+          }
+        }
+      }
+    } catch (e) {}
+
+    function removeExpired() {
+      try {
+        var now = Date.now();
+        for (var it = map.entries(), res = it.next(); !res.done; res = it.next()) {
+          var key = res.value[0];
+          var entry = res.value[1];
+          if (!entry || typeof entry.ts !== 'number' || now - entry.ts > ttl) {
+            map.delete(key);
+          }
+        }
+      } catch (e) {}
+    }
+
+    return {
+      get: function(key) {
+        removeExpired();
+        if (!map.has(key)) return null;
+        var entry = map.get(key);
+        if (!entry) return null;
+        // move to recently used
+        map.delete(key);
+        map.set(key, entry);
+        return entry.value;
+      },
+      set: function(key, value) {
+        removeExpired();
+        var entry = { value: value, ts: Date.now() };
+        if (map.has(key)) map.delete(key);
+        map.set(key, entry);
+        while (map.size > maxEntries) {
+          var firstKey = map.keys().next().value;
+          map.delete(firstKey);
+        }
+        persist();
+      }
+    };
+  }
+
+  var cache = createLRUCache('osrm_nominatim_cache_v1', 128, 24 * 60 * 60 * 1000);
+  var supportsFetch = typeof fetch === 'function';
+  var serviceBase = (normalizedNominatimUrl && normalizedNominatimUrl.length > 0) ? normalizedNominatimUrl.replace(/\/+$/, '') + '/' : 'https://nominatim.openstreetmap.org/';
+
+  function setInputBgFromContext(context, color) {
+    try {
+      if (!context) {
+        if (typeof document !== 'undefined' && document.activeElement && document.activeElement.tagName === 'INPUT') {
+          document.activeElement.style.backgroundColor = color;
+        }
+        return;
+      }
+      var input = null;
+      if (context.input && context.input.style) input = context.input;
+      else if (context._input && context._input.style) input = context._input;
+      else if (context.container && context.container.querySelector) input = context.container.querySelector('input');
+      else if (context.querySelector) input = context.querySelector('input');
+      if (!input && typeof document !== 'undefined' && document.activeElement && document.activeElement.tagName === 'INPUT') {
+        input = document.activeElement;
+      }
+      if (input && input.style) input.style.backgroundColor = color;
+    } catch (e) {}
+  }
+
+  function buildSearchUrl(query) {
+    return serviceBase + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent(query);
+  }
+
+  function buildReverseUrl(latlng, scale) {
+    var lat = (latlng && latlng.lat) || (latlng && latlng[0]) || 0;
+    var lon = (latlng && latlng.lng) || (latlng && latlng[1]) || 0;
+    // Use zoom 18 for reverse display like original behaviour
+    var zoom = 18;
+    return serviceBase + 'reverse?format=json&addressdetails=1&lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&zoom=' + encodeURIComponent(zoom);
+  }
+
+  function parseSearchResults(json) {
+    if (!Array.isArray(json)) return [];
+    return json.map(function(r) {
+      var bbox = null;
+      try {
+        if (r.boundingbox && r.boundingbox.length === 4) {
+          bbox = L.latLngBounds(
+            L.latLng(parseFloat(r.boundingbox[0]), parseFloat(r.boundingbox[2])),
+            L.latLng(parseFloat(r.boundingbox[1]), parseFloat(r.boundingbox[3]))
+          );
+        }
+      } catch (e) {}
+      return {
+        name: r.display_name || r.name || '',
+        bbox: bbox,
+        center: L.latLng(parseFloat(r.lat), parseFloat(r.lon))
+      };
+    });
+  }
+
+  function doSearch(query, context) {
+    var url = buildSearchUrl(query);
+    var cached = cache.get(url);
+    if (cached) {
+      setInputBgFromContext(context, 'white');
+      return Promise.resolve(cached);
+    }
+    if (supportsFetch) {
+      return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
+        if (resp.status === 429) {
+          setInputBgFromContext(context, 'orange');
+          return [];
+        }
+        if (!resp.ok) {
+          setInputBgFromContext(context, '');
+          return [];
+        }
+        return resp.json().then(function(json) {
+          var results = parseSearchResults(json);
+          cache.set(url, results);
+          setInputBgFromContext(context, 'white');
+          return results;
+        }).catch(function() {
+          setInputBgFromContext(context, '');
+          return [];
+        });
+      }).catch(function() {
+        setInputBgFromContext(context, '');
+        return [];
+      });
+    }
+    // Fallback to original nominatim implementation (useful for tests/mocks)
+    return nominatim.geocode(query).then(function(results) {
+      try { cache.set(url, results); } catch (e) {}
+      setInputBgFromContext(context, 'white');
       return results;
-    }).catch(function() {
-      var fallback = [];
-      if (typeof cb === 'function') cb.call(context, fallback);
-      return fallback;
+    }).catch(function(err) {
+      if (err && err.status === 429) setInputBgFromContext(context, 'orange');
+      else setInputBgFromContext(context, '');
+      return [];
+    });
+  }
+
+  function doReverse(latlng, scale, context) {
+    var url = buildReverseUrl(latlng, scale);
+    var cached = cache.get(url);
+    if (cached) {
+      setInputBgFromContext(context, 'white');
+      return Promise.resolve(cached);
+    }
+    if (supportsFetch) {
+      return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
+        if (resp.status === 429) {
+          setInputBgFromContext(context, 'orange');
+          return [];
+        }
+        if (!resp.ok) {
+          setInputBgFromContext(context, '');
+          return [];
+        }
+        return resp.json().then(function(json) {
+          var bbox = null;
+          try {
+            if (json.boundingbox && json.boundingbox.length === 4) {
+              bbox = L.latLngBounds(
+                L.latLng(parseFloat(json.boundingbox[0]), parseFloat(json.boundingbox[2])),
+                L.latLng(parseFloat(json.boundingbox[1]), parseFloat(json.boundingbox[3]))
+              );
+            }
+          } catch (e) {}
+          var res = [{
+            name: json.display_name || json.name || '',
+            bbox: bbox,
+            center: L.latLng(parseFloat(json.lat), parseFloat(json.lon))
+          }];
+          cache.set(url, res);
+          setInputBgFromContext(context, 'white');
+          return res;
+        }).catch(function() {
+          setInputBgFromContext(context, '');
+          return [];
+        });
+      }).catch(function() {
+        setInputBgFromContext(context, '');
+        return [];
+      });
+    }
+    // Fallback to original nominatim implementation (useful for tests/mocks)
+    return nominatim.reverse(latlng, scale).then(function(results) {
+      try { cache.set(url, results); } catch (e) {}
+      setInputBgFromContext(context, 'white');
+      return results;
+    }).catch(function(err) {
+      if (err && err.status === 429) setInputBgFromContext(context, 'orange');
+      else setInputBgFromContext(context, '');
+      return [];
     });
   }
 
   // Helper: reverse-geocodes coordinates for display name, but preserves exact latlng.
-  function coordResult(latlng, query) {
+  function coordResult(latlng, query, context) {
     // Use scale corresponding to zoom level 18 (was hard-coded as 256 * 2^18 = 67108864)
-    return nominatim.reverse(latlng, L.CRS.EPSG3857.scale(18)).then(function(results) {
+    return doReverse(latlng, L.CRS.EPSG3857.scale(18), context).then(function(results) {
       if (results && results.length > 0) {
         return [L.extend({}, results[0], {
           center: latlng,
@@ -92,9 +323,19 @@ geocoder.coordPreserving = function(nominatimUrl) {
     geocode: function(query, cb, context) {
       var latlng = parseCoords(query);
       if (latlng) {
-        return withCallback(coordResult(latlng, query), cb, context);
+        return coordResult(latlng, query, context).then(function(results) {
+          if (typeof cb === 'function') cb.call(context, results);
+          return results;
+        }).catch(function() {
+          var fallback = [];
+          if (typeof cb === 'function') cb.call(context, fallback);
+          return fallback;
+        });
       }
-      return withCallback(nominatim.geocode(query), cb, context);
+      return doSearch(query, context).then(function(results) {
+        if (typeof cb === 'function') cb.call(context, results);
+        return results;
+      });
     },
 
     suggest: function(query, cb, context) {
@@ -102,13 +343,22 @@ geocoder.coordPreserving = function(nominatimUrl) {
       if (latlng) {
         // Coordinate input: return result with exact center so the
         // auto-selected dropdown item preserves the typed location.
-        return withCallback(coordResult(latlng, query), cb, context);
+        return coordResult(latlng, query, context).then(function(results) {
+          if (typeof cb === 'function') cb.call(context, results);
+          return results;
+        });
       }
-      return withCallback(nominatim.geocode(query), cb, context);
+      return doSearch(query, context).then(function(results) {
+        if (typeof cb === 'function') cb.call(context, results);
+        return results;
+      });
     },
 
     reverse: function(latlng, scale, cb, context) {
-      return withCallback(nominatim.reverse(latlng, scale), cb, context);
+      return doReverse(latlng, scale, context).then(function(results) {
+        if (typeof cb === 'function') cb.call(context, results);
+        return results;
+      });
     }
   };
 };

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -45,6 +45,29 @@ function parseCoords(query) {
   return m ? L.latLng(+m[1], +m[2]) : null;
 }
 
+var globalNominatimCache = null;
+var liveRegionEl = null;
+function announceRateLimit(msg) {
+  try {
+    if (typeof document === 'undefined') return;
+    if (!liveRegionEl) {
+      liveRegionEl = document.getElementById('osrm-nominatim-live');
+      if (!liveRegionEl) {
+        liveRegionEl = document.createElement('div');
+        liveRegionEl.id = 'osrm-nominatim-live';
+        liveRegionEl.setAttribute('aria-live', 'polite');
+        liveRegionEl.style.position = 'absolute';
+        liveRegionEl.style.left = '-9999px';
+        liveRegionEl.style.width = '1px';
+        liveRegionEl.style.height = '1px';
+        liveRegionEl.style.overflow = 'hidden';
+        document.body.appendChild(liveRegionEl);
+      }
+    }
+    liveRegionEl.textContent = msg;
+  } catch (e) {}
+}
+
 // Returns a geocoder that, when given coordinate input, preserves the exact
 // lat/lon instead of snapping to the nearest address, while still calling
 // Nominatim reverse-geocode so a human-readable name is displayed.
@@ -158,12 +181,9 @@ geocoder.coordPreserving = function(nominatimUrl) {
         if (!map.has(key)) return null;
         var entry = map.get(key);
         if (!entry) return null;
-        // move to recently used
+        // move to recently used (in-memory only)
         map.delete(key);
         map.set(key, entry);
-        try {
-          persist();
-        } catch (e) {}
         return entry.value;
       },
       set: function(key, value) {
@@ -180,26 +200,19 @@ geocoder.coordPreserving = function(nominatimUrl) {
     };
   }
 
-  var cache = createLRUCache('osrm_nominatim_cache_v1', 128, 24 * 60 * 60 * 1000);
+  if (!globalNominatimCache) globalNominatimCache = createLRUCache('osrm_nominatim_cache_v1', 128, 24 * 60 * 60 * 1000);
+  var cache = globalNominatimCache;
   var supportsFetch = typeof fetch === 'function';
   var serviceBase = (normalizedNominatimUrl && normalizedNominatimUrl.length > 0) ? normalizedNominatimUrl.replace(/\/+$/, '') + '/' : 'https://nominatim.openstreetmap.org/';
 
   function setInputBgFromContext(context, color) {
     try {
-      if (!context) {
-        if (typeof document !== 'undefined' && document.activeElement && document.activeElement.tagName === 'INPUT') {
-          document.activeElement.style.backgroundColor = color;
-        }
-        return;
-      }
+      if (!context) return;
       var input = null;
       if (context.input && context.input.style) input = context.input;
       else if (context._input && context._input.style) input = context._input;
       else if (context.container && context.container.querySelector) input = context.container.querySelector('input');
       else if (context.querySelector) input = context.querySelector('input');
-      if (!input && typeof document !== 'undefined' && document.activeElement && document.activeElement.tagName === 'INPUT') {
-        input = document.activeElement;
-      }
       if (input && input.style) input.style.backgroundColor = color;
     } catch (e) {}
   }
@@ -261,6 +274,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
       return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
         if (resp.status === 429) {
           setInputBgFromContext(context, 'orange');
+          announceRateLimit('Geocoder rate-limited (HTTP 429)');
           return [];
         }
         if (!resp.ok) {
@@ -293,6 +307,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
       }).catch(function(err) {
         if (err && err.status === 429) {
           setInputBgFromContext(context, 'orange');
+          announceRateLimit('Geocoder rate-limited (HTTP 429)');
           return [];
         }
         // fall back to fetch path when available
@@ -326,8 +341,12 @@ geocoder.coordPreserving = function(nominatimUrl) {
         setInputBgFromContext(context, 'white');
         return results;
       }).catch(function(err) {
-        if (err && err.status === 429) setInputBgFromContext(context, 'orange');
-        else setInputBgFromContext(context, '');
+        if (err && err.status === 429) {
+          setInputBgFromContext(context, 'orange');
+          announceRateLimit('Geocoder rate-limited (HTTP 429)');
+        } else {
+          setInputBgFromContext(context, '');
+        }
         return [];
       });
     }
@@ -336,6 +355,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
       return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
         if (resp.status === 429) {
           setInputBgFromContext(context, 'orange');
+          announceRateLimit('Geocoder rate-limited (HTTP 429)');
           return [];
         }
         if (!resp.ok) {

--- a/test/geocoder_cache.test.js
+++ b/test/geocoder_cache.test.js
@@ -45,7 +45,12 @@ describe('geocoder cache', function() {
 
   test('caches successful search responses and reuses cache', async function() {
     jest.resetModules();
-    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+    jest.doMock('leaflet', function() { 
+      var m = makeLeafletMock();
+      // Force fetch path by returning an object without a geocode() function
+      m.Control.Geocoder.nominatim = jest.fn(function() { return {}; });
+      return m;
+    });
 
     var fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async function() {
       return [{ display_name: 'Place A', lat: '10', lon: '20', boundingbox: ['10','11','20','21'] }];
@@ -80,7 +85,11 @@ describe('geocoder cache', function() {
 
   test('sets input background to orange on 429', async function() {
     jest.resetModules();
-    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+    jest.doMock('leaflet', function() { 
+      var m = makeLeafletMock();
+      m.Control.Geocoder.nominatim = jest.fn(function() { return {}; });
+      return m;
+    });
 
     var fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 429 });
     global.fetch = fetchMock;
@@ -104,7 +113,11 @@ describe('geocoder cache', function() {
     localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(stored));
 
     jest.resetModules();
-    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+    jest.doMock('leaflet', function() { 
+      var m = makeLeafletMock();
+      m.Control.Geocoder.nominatim = jest.fn(function() { return {}; });
+      return m;
+    });
 
     var fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async function() {
       return [{ display_name: 'NewOld', lat: '11', lon: '22', boundingbox: ['11','12','22','23'] }];

--- a/test/geocoder_cache.test.js
+++ b/test/geocoder_cache.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+// Provide a localStorage shim when tests run in a Node environment (Jest may use "node" env).
+if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+  global.localStorage = (function () {
+    var store = Object.create(null);
+    return {
+      getItem: function (k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+      setItem: function (k, v) { store[k] = String(v); },
+      removeItem: function (k) { delete store[k]; },
+      clear: function () { store = Object.create(null); }
+    };
+  })();
+}
+
+
+// Tests for the Nominatim caching behaviour added to src/geocoder.js
+// - caches successful responses and reuses them
+// - sets input bg to orange on 429
+// - expires entries older than 24h on load
+// - evicts oldest entry when capacity exceeded (LRU)
+
+describe('geocoder cache', function() {
+  // helper that provides a minimal leaflet mock used by coordPreserving
+  function makeLeafletMock() {
+    return {
+      Control: { Geocoder: { nominatim: jest.fn(function() { return { geocode: jest.fn(function() { return Promise.resolve([]); }), reverse: jest.fn(function() { return Promise.resolve([]); }) }; }) } },
+      CRS: { EPSG3857: { scale: function() { return 1; } } },
+      latLng: function(lat, lng) { return { lat: +lat, lng: +lng, toBounds: function() { return {}; } }; },
+      extend: Object.assign
+    };
+  }
+
+  beforeEach(function() {
+    jest.resetModules();
+    if (typeof localStorage !== 'undefined' && localStorage.clear) localStorage.clear();
+    // ensure no global fetch leak between tests
+    try { delete global.fetch; } catch (e) {}
+  });
+
+  afterEach(function() {
+    try { delete global.fetch; } catch (e) {}
+    jest.clearAllMocks && jest.clearAllMocks();
+  });
+
+  test('caches successful search responses and reuses cache', async function() {
+    jest.resetModules();
+    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+
+    var fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async function() {
+      return [{ display_name: 'Place A', lat: '10', lon: '20', boundingbox: ['10','11','20','21'] }];
+    } });
+    global.fetch = fetchMock;
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving('https://nominatim.example/');
+
+    var ctx = { input: { style: {} } };
+
+    var res1 = await g.geocode('Somewhere', undefined, ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(Array.isArray(res1)).toBe(true);
+    expect(res1.length).toBe(1);
+    expect(ctx.input.style.backgroundColor).toBe('white');
+
+    // second call should come from cache (no additional fetch)
+    var res2 = await g.geocode('Somewhere', undefined, ctx);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res2.length).toBe(1);
+    expect(ctx.input.style.backgroundColor).toBe('white');
+
+    // persisted cache should contain the search URL key
+    var raw = localStorage.getItem('osrm_nominatim_cache_v1');
+    expect(raw).toBeTruthy();
+    var entries = JSON.parse(raw);
+    var expectedUrl = 'https://nominatim.example/search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('Somewhere');
+    var found = entries.find(function(e) { return e[0] === expectedUrl; });
+    expect(found).toBeDefined();
+  });
+
+  test('sets input background to orange on 429', async function() {
+    jest.resetModules();
+    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+
+    var fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 429 });
+    global.fetch = fetchMock;
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving('https://nominatim.example/');
+
+    var ctx = { input: { style: {} } };
+    var res = await g.geocode('RateLimited', undefined, ctx);
+    expect(Array.isArray(res)).toBe(true);
+    expect(res.length).toBe(0);
+    expect(ctx.input.style.backgroundColor).toBe('orange');
+  });
+
+  test('expires old entries on load (TTL)', async function() {
+    // create an expired entry in localStorage before the cache is created
+    var q = 'OldPlace';
+    var url = 'https://nominatim.example/search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent(q);
+    var oldTs = Date.now() - (24 * 60 * 60 * 1000) - 1000; // older than 24h
+    var stored = [[url, { value: [{ name: 'Old', center: { lat: 11, lng: 22 } }], ts: oldTs }]];
+    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(stored));
+
+    jest.resetModules();
+    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+
+    var fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async function() {
+      return [{ display_name: 'NewOld', lat: '11', lon: '22', boundingbox: ['11','12','22','23'] }];
+    } });
+    global.fetch = fetchMock;
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving('https://nominatim.example/');
+    var ctx = { input: { style: {} } };
+
+    var res = await g.geocode(q, undefined, ctx);
+    // expired entry should not be used -> fetch called
+    expect(fetchMock).toHaveBeenCalled();
+    expect(ctx.input.style.backgroundColor).toBe('white');
+  });
+
+  test('evicts oldest entry when capacity exceeded', async function() {
+    // pre-populate localStorage with 128 entries in insertion order
+    var service = 'https://nominatim.example/';
+    var now = Date.now();
+    var entries = [];
+    for (var i = 0; i < 128; i++) {
+      var u = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q' + i);
+      entries.push([u, { value: [{ name: 'P' + i, center: { lat: i, lng: i } }], ts: now }]);
+    }
+    localStorage.setItem('osrm_nominatim_cache_v1', JSON.stringify(entries));
+
+    jest.resetModules();
+    jest.doMock('leaflet', function() { return makeLeafletMock(); });
+
+    var fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200, json: async function() {
+      return [{ display_name: 'New', lat: '1', lon: '2', boundingbox: ['1','1','2','2'] }];
+    } });
+    global.fetch = fetchMock;
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving(service);
+    var ctx = { input: { style: {} } };
+
+    var res = await g.geocode('NewPlace', undefined, ctx);
+
+    var raw = localStorage.getItem('osrm_nominatim_cache_v1');
+    expect(raw).toBeTruthy();
+    var arr = JSON.parse(raw);
+    // ensure size capped at 128 and oldest (q0) removed while NewPlace present
+    expect(arr.length).toBeLessThanOrEqual(128);
+    var firstExpected = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('q0');
+    expect(arr.find(function(e) { return e[0] === firstExpected; })).toBeUndefined();
+    var newUrl = service + 'search?format=json&addressdetails=1&limit=5&q=' + encodeURIComponent('NewPlace');
+    expect(arr.find(function(e) { return e[0] === newUrl; })).toBeDefined();
+  });
+
+});

--- a/test/geocoder_cache.test.js
+++ b/test/geocoder_cache.test.js
@@ -170,4 +170,52 @@ describe('geocoder cache', function() {
     expect(arr.find(function(e) { return e[0] === newUrl; })).toBeDefined();
   });
 
+  test('uses nominatim geocode path and caches results', async function() {
+    jest.resetModules();
+    var geocodeMock = jest.fn().mockResolvedValue([{ name: 'NPlace', center: { lat: 10, lng: 20 }, bbox: [10,11,20,21] }]);
+    jest.doMock('leaflet', function() {
+      var m = makeLeafletMock();
+      m.Control.Geocoder.nominatim = jest.fn(function() { return { geocode: geocodeMock }; });
+      return m;
+    });
+    try { delete global.fetch; } catch (e) {}
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving('https://nominatim.example/');
+    var ctx = { input: { style: {} } };
+
+    var res1 = await g.geocode('NPlace', undefined, ctx);
+    expect(geocodeMock).toHaveBeenCalledTimes(1);
+    expect(ctx.input.style.backgroundColor).toBe('white');
+
+    var res2 = await g.geocode('NPlace', undefined, ctx);
+    expect(geocodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('caches nominatim.reverse results and reuses them', async function() {
+    jest.resetModules();
+    var reverseMock = jest.fn().mockResolvedValue([{ name: 'RPlace', center: { lat: 11, lng: 22 }, bbox: [11,12,22,23] }]);
+    var nominatimFactory = jest.fn(function() { return { reverse: reverseMock }; });
+    jest.doMock('leaflet', function() {
+      return {
+        Control: { Geocoder: { nominatim: nominatimFactory } },
+        CRS: { EPSG3857: { scale: function() { return 1; } } },
+        latLng: function(lat, lng) { return { lat: +lat, lng: +lng, toBounds: function() { return {}; } }; },
+        extend: Object.assign
+      };
+    });
+    try { delete global.fetch; } catch (e) {}
+
+    var geocoder = require('../src/geocoder');
+    var g = geocoder.coordPreserving('https://nominatim.example/');
+    var ctx = { input: { style: {} } };
+
+    var res1 = await g.reverse({ lat: 11, lng: 22 }, 18, undefined, ctx);
+    expect(reverseMock).toHaveBeenCalledTimes(1);
+    expect(ctx.input.style.backgroundColor).toBe('white');
+
+    var res2 = await g.reverse({ lat: 11, lng: 22 }, 18, undefined, ctx);
+    expect(reverseMock).toHaveBeenCalledTimes(1);
+  });
+
 });


### PR DESCRIPTION
Adds a persistent LRU cache (128 entries, 24h TTL) for successful Nominatim search/reverse responses keyed by query URL. Sets input background to white on success and orange on 429. Includes Jest tests in test/geocoder_cache.test.js.