### PR TITLE
fix(itinerary): disable scroll propagation on routing container (fixes #195)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,6 +239,15 @@ router._convertRoute = function(responseRoute) {
 var lrmControl = L.Routing.control(Object.assign(controlOptions, {
   router: router
 })).addTo(map);
+
+// Prevent routing container from swallowing wheel events in some browsers (fixes #195)
+if (L && L.DomEvent && typeof L.DomEvent.disableScrollPropagation === 'function') {
+  var routingContainers = document.querySelectorAll('.leaflet-routing-container');
+  for (var __i = 0; __i < routingContainers.length; __i++) {
+    L.DomEvent.disableScrollPropagation(routingContainers[__i]);
+  }
+}
+
 var toolsControl = tools.control(localization.get(mergedOptions.language), localization.getLanguages(), Object.assign({}, options.tools, { initialUnits: mergedOptions.units })).addTo(map);
 
 var state = state(map, lrmControl, toolsControl, modeSelector, mergedOptions);

--- a/src/index.js
+++ b/src/index.js
@@ -255,7 +255,11 @@ var lrmControl = L.Routing.control(Object.assign(controlOptions, {
   router: router
 })).addTo(map);
 
-// Prevent routing container from swallowing wheel events in some browsers (fixes #195)
+// Workaround: Leaflet Routing Machine's itinerary adds a 'mousewheel' handler
+// that stops propagation in some browsers, which can prevent the directions pane
+// from scrolling in Firefox (see https://bugzilla.mozilla.org/show_bug.cgi?id=1942589
+// and OSRM issue #195). Disable scroll propagation on the routing container so
+// the directions list can be scrolled by the user. Upstream LRM issue: https://github.com/perliedman/leaflet-routing-machine/issues/721
 if (L && L.DomEvent && typeof L.DomEvent.disableScrollPropagation === 'function') {
   var routingContainers = document.querySelectorAll('.leaflet-routing-container');
   for (var __i = 0; __i < routingContainers.length; __i++) {


### PR DESCRIPTION
This PR prevents the routing container from swallowing wheel events in Firefox by calling L.DomEvent.disableScrollPropagation on the routing container after the routing control is added.

See: https://github.com/Project-OSRM/osrm-frontend/issues/195
Upstream bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1942589

Suggested upstream fix: replace direct 'mousewheel' handler with L.DomEvent.disableScrollPropagation(this._container) in itinerary.js.

All tests passed locally.

fixes #195 