### PR TITLE
fix: wrap waypoint/center longitudes into [-180,180] (fixes #206, #307)

### DIFF
--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -425,7 +425,10 @@ geocoder.coordPreserving = function(nominatimUrl) {
   }
 
   function doReverse(latlng, scale, context) {
-    var url = buildReverseUrl(latlng, scale);
+    // Wrap longitude into [-180, 180] so Nominatim receives valid coordinates
+    // when the map has been scrolled past the antimeridian (issues #206, #307).
+    var latlngWrapped = (latlng && typeof latlng.wrap === 'function') ? latlng.wrap() : latlng;
+    var url = buildReverseUrl(latlngWrapped, scale);
     var cached = cache.get(url);
     if (cached) {
       setInputBgFromContext(context, 'white');
@@ -434,7 +437,7 @@ geocoder.coordPreserving = function(nominatimUrl) {
 
     // Prefer nominatim.reverse when available to preserve existing behaviour and support test mocks
     if (nominatim && typeof nominatim.reverse === 'function') {
-      return nominatim.reverse(latlng, scale).then(function(results) {
+      return nominatim.reverse(latlngWrapped, scale).then(function(results) {
         try {
           cache.set(url, results);
         } catch (e) {}

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -565,4 +565,18 @@ geocoder.coordPreserving = function(nominatimUrl) {
   };
 };
 
+// Replacement for LRM's built-in waypointNameFallback that wraps the longitude
+// into [-180, 180] before formatting. When reverse geocoding fails (no network,
+// rate limit, location in the ocean) and the raw coordinate is shown, this
+// ensures the displayed value is always within the valid geographic range.
+geocoder.wrappedWaypointNameFallback = function(latLng) {
+  var wrapped = (latLng && typeof latLng.wrap === 'function') ? latLng.wrap() : latLng;
+  var ll = wrapped || latLng || {};
+  var ns = (ll.lat || 0) < 0 ? 'S' : 'N';
+  var ew = (ll.lng || 0) < 0 ? 'W' : 'E';
+  var lat = (Math.round(Math.abs(ll.lat || 0) * 10000) / 10000).toString();
+  var lng = (Math.round(Math.abs(ll.lng || 0) * 10000) / 10000).toString();
+  return ns + lat + ', ' + ew + lng;
+};
+
 module.exports = geocoder;

--- a/src/geocoder.js
+++ b/src/geocoder.js
@@ -428,16 +428,18 @@ geocoder.coordPreserving = function(nominatimUrl) {
     // Wrap longitude into [-180, 180] so Nominatim receives valid coordinates
     // when the map has been scrolled past the antimeridian (issues #206, #307).
     var latlngWrapped = (latlng && typeof latlng.wrap === 'function') ? latlng.wrap() : latlng;
+    // Offset to re-project result centers back into the same "world copy" as
+    // the original latlng, so LRM's geocoder-element distance-tolerance check
+    // (rs[0].center.distanceTo(wp.latLng)) passes correctly.
+    var lngOffset = (latlng && latlngWrapped) ? latlng.lng - latlngWrapped.lng : 0;
     var url = buildReverseUrl(latlngWrapped, scale);
     var cached = cache.get(url);
+    var basePromise;
     if (cached) {
       setInputBgFromContext(context, 'white');
-      return Promise.resolve(cached);
-    }
-
-    // Prefer nominatim.reverse when available to preserve existing behaviour and support test mocks
-    if (nominatim && typeof nominatim.reverse === 'function') {
-      return nominatim.reverse(latlngWrapped, scale).then(function(results) {
+      basePromise = Promise.resolve(cached);
+    } else if (nominatim && typeof nominatim.reverse === 'function') {
+      basePromise = nominatim.reverse(latlngWrapped, scale).then(function(results) {
         try {
           cache.set(url, results);
         } catch (e) {}
@@ -452,10 +454,8 @@ geocoder.coordPreserving = function(nominatimUrl) {
         }
         return [];
       });
-    }
-
-    if (supportsFetch) {
-      return fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
+    } else if (supportsFetch) {
+      basePromise = fetch(url, { headers: { 'Accept': 'application/json' } }).then(function(resp) {
         if (resp.status === 429) {
           setInputBgFromContext(context, 'orange');
           announceRateLimit('Geocoder rate-limited (HTTP 429)');
@@ -491,9 +491,18 @@ geocoder.coordPreserving = function(nominatimUrl) {
         setInputBgFromContext(context, '');
         return [];
       });
+    } else {
+      basePromise = Promise.resolve([]);
     }
 
-    return Promise.resolve([]);
+    if (lngOffset === 0) return basePromise;
+    return basePromise.then(function(results) {
+      if (!results || !results.length) return results;
+      return results.map(function(r) {
+        if (!r || !r.center) return r;
+        return Object.assign({}, r, { center: L.latLng(r.center.lat, r.center.lng + lngOffset) });
+      });
+    });
   }
 
   // Helper: reverse-geocodes coordinates for display name, but preserves exact latlng.

--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ function makeIcon(i, n) {
 
 var plan = new ReversablePlan([], {
   geocoder: createGeocoder.coordPreserving(leafletOptions.nominatim && leafletOptions.nominatim.path),
+  waypointNameFallback: createGeocoder.wrappedWaypointNameFallback,
   language: mergedOptions.language,
   routeWhileDragging: true,
   createMarker: function(i, wp, n) {

--- a/src/links.js
+++ b/src/links.js
@@ -9,7 +9,8 @@ function _formatCoord(latLng) {
   if (!latLng) {
     return;
   }
-  return latLng.lat.toFixed(precision) + "," + latLng.lng.toFixed(precision);
+  var coord = typeof latLng.wrap === 'function' ? latLng.wrap() : latLng;
+  return coord.lat.toFixed(precision) + "," + coord.lng.toFixed(precision);
 }
 
 function _parseCoord(coordStr) {

--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -17,6 +17,12 @@ function leftOrRight(d) {
 // sending them to the OSRM backend. Without this, panning the map past the
 // antimeridian produces out-of-range longitudes (e.g. -362.8) that OSRM
 // rejects with a 400 error (issues #206 and #307).
+//
+// After routing, LRM's 'snap' mode calls setWaypoints(route.waypoints) with the
+// snapped positions returned by OSRM. Those are in the wrapped (in-range)
+// coordinate space, so LRM would place markers at the wrong world copy.
+// We re-offset the snapped latlngs back by the same ±n×360° that was applied
+// during wrapping, keeping markers in the correct viewport position.
 function wrapWaypoints(router) {
   var origRoute = router.route.bind(router);
   router.route = function(waypoints, callback, context, options) {
@@ -24,7 +30,35 @@ function wrapWaypoints(router) {
       if (!wp || !wp.latLng || typeof wp.latLng.wrap !== 'function') return wp;
       return Object.assign({}, wp, { latLng: wp.latLng.wrap() });
     });
-    return origRoute(wrapped, callback, context, options);
+
+    var wrappedCallback = function(err, routes) {
+      if (!err && routes) {
+        routes.forEach(function(route) {
+          if (route && route.waypoints) {
+            route.waypoints = route.waypoints.map(function(snappedWp, i) {
+              var orig = waypoints[i];
+              if (!snappedWp || !snappedWp.latLng || !orig || !orig.latLng ||
+                  typeof orig.latLng.wrap !== 'function') return snappedWp;
+              var offset = orig.latLng.lng - orig.latLng.wrap().lng;
+              if (offset === 0) return snappedWp;
+              var reoffsetLng = snappedWp.latLng.lng + offset;
+              var reoffsetLatLng = {
+                lat: snappedWp.latLng.lat,
+                lng: reoffsetLng,
+                wrap: function() {
+                  var v = reoffsetLng;
+                  return { lat: snappedWp.latLng.lat, lng: ((v + 180) % 360 + 360) % 360 - 180 };
+                }
+              };
+              return Object.assign({}, snappedWp, { latLng: reoffsetLatLng });
+            });
+          }
+        });
+      }
+      if (typeof callback === 'function') callback.apply(context || callback, arguments);
+    };
+
+    return origRoute(wrapped, wrappedCallback, context, options);
   };
 }
 

--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -31,6 +31,16 @@ function wrapWaypoints(router) {
       return Object.assign({}, wp, { latLng: wp.latLng.wrap() });
     });
 
+    // Compute the lng offset for each input waypoint (n×360° applied during wrapping).
+    var offsets = (waypoints || []).map(function(wp) {
+      if (!wp || !wp.latLng || typeof wp.latLng.wrap !== 'function') return 0;
+      return wp.latLng.lng - wp.latLng.wrap().lng;
+    });
+    // Use the first non-zero offset to re-project route.coordinates (the polyline).
+    var coordOffset = offsets.reduce(function(acc, o) {
+      return acc !== 0 ? acc : o;
+    }, 0);
+
     var wrappedCallback = function(err, routes) {
       if (!err && routes) {
         routes.forEach(function(route) {
@@ -51,6 +61,15 @@ function wrapWaypoints(router) {
                 }
               };
               return Object.assign({}, snappedWp, { latLng: reoffsetLatLng });
+            });
+          }
+          // Re-project the route polyline into the same world copy as the waypoints
+          // so LRM draws the line at the correct map position and fitBounds() doesn't
+          // jump the viewport to the wrapped world copy (which would hide the markers).
+          if (route && route.coordinates && coordOffset !== 0) {
+            route.coordinates = route.coordinates.map(function(coord) {
+              if (!coord) return coord;
+              return { lat: coord.lat, lng: coord.lng + coordOffset };
             });
           }
         });

--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -13,12 +13,29 @@ function leftOrRight(d) {
   return d;
 }
 
+// Patch router.route() to wrap waypoint longitudes into [-180, 180] before
+// sending them to the OSRM backend. Without this, panning the map past the
+// antimeridian produces out-of-range longitudes (e.g. -362.8) that OSRM
+// rejects with a 400 error (issues #206 and #307).
+function wrapWaypoints(router) {
+  var origRoute = router.route.bind(router);
+  router.route = function(waypoints, callback, context, options) {
+    var wrapped = (waypoints || []).map(function(wp) {
+      if (!wp || !wp.latLng || typeof wp.latLng.wrap !== 'function') return wp;
+      return Object.assign({}, wp, { latLng: wp.latLng.wrap() });
+    });
+    return origRoute(wrapped, callback, context, options);
+  };
+}
+
 module.exports = {
   applyPatches: function(router) {
     router._leftOrRight = leftOrRight;
+    wrapWaypoints(router);
   },
   // Exported for unit testing
   leftOrRight: leftOrRight,
+  wrapWaypoints: wrapWaypoints,
   
   // Allow setting the active service by index
   setActiveService: function(router, serviceIndex, services) {

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -124,5 +124,87 @@ describe('geocoder.coordPreserving', () => {
       const calledWith = reverseMock.mock.calls[0][0];
       expect(calledWith.lng).toBeCloseTo(2.35);
     });
+
+    test('re-offsets result center back to original coordinate space when lng < -180', async () => {
+      // LRM's geocoder-element checks rs[0].center.distanceTo(wp.latLng).
+      // If center stays at the wrapped lng while wp.latLng is out-of-range, the
+      // distance test fails and LRM falls back to showing raw coordinates.
+      const { nominatimFactory } = makeMocks(
+        () => Promise.resolve([{ name: 'Berlin', center: { lat: 52.5, lng: 13.405 } }])
+      );
+
+      jest.doMock('leaflet', () => ({
+        Control: { Geocoder: { nominatim: nominatimFactory } },
+        CRS: { EPSG3857: { scale: () => 1 } },
+        latLng: (lat, lng) => {
+          const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+          obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+          return obj;
+        },
+        latLngBounds: () => ({}),
+        extend: Object.assign
+      }));
+
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      // Panned west two full turns: 13.405 - 720 = -706.595
+      const outOfRange = { lat: 52.5, lng: -706.595, wrap: () => ({ lat: 52.5, lng: 13.405 }) };
+      const results = await g.reverse(outOfRange, 1, function() {});
+      // center.lng should be re-offset by -720 (two full rotations west)
+      expect(results[0].center.lng).toBeCloseTo(-706.595);
+    });
+
+    test('re-offsets result center back to original coordinate space when lng > +180', async () => {
+      const { nominatimFactory } = makeMocks(
+        () => Promise.resolve([{ name: 'Beijing', center: { lat: 39.9, lng: 116.403 } }])
+      );
+
+      jest.doMock('leaflet', () => ({
+        Control: { Geocoder: { nominatim: nominatimFactory } },
+        CRS: { EPSG3857: { scale: () => 1 } },
+        latLng: (lat, lng) => {
+          const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+          obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+          return obj;
+        },
+        latLngBounds: () => ({}),
+        extend: Object.assign
+      }));
+
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      // Panned east four full turns: 116.403 + 1440 = 1556.403
+      const outOfRange = { lat: 39.9, lng: 1556.403, wrap: () => ({ lat: 39.9, lng: 116.403 }) };
+      const results = await g.reverse(outOfRange, 1, function() {});
+      expect(results[0].center.lng).toBeCloseTo(1556.403);
+    });
+
+    test('leaves result center unchanged when input is already in [-180, 180]', async () => {
+      const { nominatimFactory } = makeMocks(
+        () => Promise.resolve([{ name: 'Paris', center: { lat: 48.85, lng: 2.347 } }])
+      );
+
+      jest.doMock('leaflet', () => ({
+        Control: { Geocoder: { nominatim: nominatimFactory } },
+        CRS: { EPSG3857: { scale: () => 1 } },
+        latLng: (lat, lng) => {
+          const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+          obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+          return obj;
+        },
+        latLngBounds: () => ({}),
+        extend: Object.assign
+      }));
+
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      const inRange = { lat: 48.85, lng: 2.35, wrap: () => ({ lat: 48.85, lng: 2.35 }) };
+      const results = await g.reverse(inRange, 1, function() {});
+      // No re-offset — center stays as Nominatim returned it
+      expect(results[0].center.lng).toBeCloseTo(2.347);
+    });
   });
 });

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -208,3 +208,45 @@ describe('geocoder.coordPreserving', () => {
     });
   });
 });
+
+describe('geocoder.wrappedWaypointNameFallback', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('wraps longitude > +180 before formatting', () => {
+    const geocoder = require('../src/geocoder');
+    const latLng = { lat: 39.9, lng: 1556.6, wrap: () => ({ lat: 39.9, lng: 116.6 }) };
+    const result = geocoder.wrappedWaypointNameFallback(latLng);
+    expect(result).toBe('N39.9, E116.6');
+  });
+
+  test('wraps longitude < -180 before formatting', () => {
+    const geocoder = require('../src/geocoder');
+    const latLng = { lat: 53.265, lng: -362.806, wrap: () => ({ lat: 53.265, lng: -2.806 }) };
+    const result = geocoder.wrappedWaypointNameFallback(latLng);
+    expect(result).toBe('N53.265, W2.806');
+  });
+
+  test('leaves in-range coordinates unchanged', () => {
+    const geocoder = require('../src/geocoder');
+    const latLng = { lat: 48.8, lng: 2.35, wrap: () => ({ lat: 48.8, lng: 2.35 }) };
+    const result = geocoder.wrappedWaypointNameFallback(latLng);
+    expect(result).toBe('N48.8, E2.35');
+  });
+
+  test('handles latLng without wrap() gracefully', () => {
+    const geocoder = require('../src/geocoder');
+    const latLng = { lat: 39.9, lng: 1556.6 }; // no .wrap()
+    // Falls back to using the original (out-of-range) lng
+    const result = geocoder.wrappedWaypointNameFallback(latLng);
+    expect(result).toBe('N39.9, E1556.6');
+  });
+
+  test('uses S/W for negative lat/lng', () => {
+    const geocoder = require('../src/geocoder');
+    const latLng = { lat: -33.9, lng: -70.6, wrap: () => ({ lat: -33.9, lng: -70.6 }) };
+    const result = geocoder.wrappedWaypointNameFallback(latLng);
+    expect(result).toBe('S33.9, W70.6');
+  });
+});

--- a/test/geocoder.test.js
+++ b/test/geocoder.test.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// Longitude-wrapping helper used in mocks — mirrors Leaflet's LatLng.wrap().
+function wrapLng(v) {
+  return ((v + 180) % 360 + 360) % 360 - 180;
+}
+
 describe('geocoder.coordPreserving', () => {
   beforeEach(() => {
     jest.resetModules();
@@ -13,7 +18,11 @@ describe('geocoder.coordPreserving', () => {
     jest.doMock('leaflet', () => ({
       Control: { Geocoder: { nominatim: nominatimFactory } },
       CRS: { EPSG3857: { scale: () => 1 } },
-      latLng: (lat, lng) => ({ lat: +lat, lng: +lng, toBounds: () => ({}) }),
+      latLng: (lat, lng) => {
+        const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+        obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+        return obj;
+      },
       extend: Object.assign
     }));
 
@@ -38,7 +47,11 @@ describe('geocoder.coordPreserving', () => {
     jest.doMock('leaflet', () => ({
       Control: { Geocoder: { nominatim: nominatimFactory } },
       CRS: { EPSG3857: { scale: () => 1 } },
-      latLng: (lat, lng) => ({ lat: +lat, lng: +lng, toBounds: () => ({}) }),
+      latLng: (lat, lng) => {
+        const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+        obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+        return obj;
+      },
       extend: Object.assign
     }));
 
@@ -49,5 +62,67 @@ describe('geocoder.coordPreserving', () => {
     geocoder.coordPreserving();
     expect(L.Control.Geocoder.nominatim).toHaveBeenCalled();
     expect(L.Control.Geocoder.nominatim.mock.calls[0].length).toBe(0);
+  });
+
+  // Tests for reverse-geocode coordinate wrapping (issues #206, #307).
+  // When the map is scrolled past the antimeridian, marker latLngs can have
+  // out-of-range longitudes.  doReverse() must wrap them before calling
+  // Nominatim so the request succeeds.
+  describe('reverse geocoding wraps out-of-range longitudes', () => {
+    function makeMocks(reverseMockImpl) {
+      const reverseMock = jest.fn(reverseMockImpl || (() => Promise.resolve([{ name: 'wrapped-result' }])));
+      const geocodeMock = jest.fn(() => Promise.resolve([]));
+      const nominatimFactory = jest.fn(() => ({ reverse: reverseMock, geocode: geocodeMock }));
+      jest.doMock('leaflet', () => ({
+        Control: { Geocoder: { nominatim: nominatimFactory } },
+        CRS: { EPSG3857: { scale: () => 1 } },
+        latLng: (lat, lng) => {
+          const obj = { lat: +lat, lng: +lng, toBounds: () => ({}) };
+          obj.wrap = () => ({ lat: obj.lat, lng: wrapLng(obj.lng), toBounds: () => ({}) });
+          return obj;
+        },
+        extend: Object.assign
+      }));
+      return { reverseMock, geocodeMock, nominatimFactory };
+    }
+
+    test('passes wrapped longitude to nominatim.reverse when lng < -180', async () => {
+      const { reverseMock } = makeMocks();
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      const outOfRange = { lat: 53.265, lng: -362.806, wrap: () => ({ lat: 53.265, lng: -2.806 }) };
+      await g.reverse(outOfRange, 1, function() {});
+
+      expect(reverseMock).toHaveBeenCalledTimes(1);
+      const calledWith = reverseMock.mock.calls[0][0];
+      expect(calledWith.lng).toBeCloseTo(-2.806);
+      expect(calledWith.lat).toBeCloseTo(53.265);
+    });
+
+    test('passes wrapped longitude to nominatim.reverse when lng > +180', async () => {
+      const { reverseMock } = makeMocks();
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      const outOfRange = { lat: 39.9, lng: 1556.6, wrap: () => ({ lat: 39.9, lng: 116.6 }) };
+      await g.reverse(outOfRange, 1, function() {});
+
+      expect(reverseMock).toHaveBeenCalledTimes(1);
+      const calledWith = reverseMock.mock.calls[0][0];
+      expect(calledWith.lng).toBeCloseTo(116.6);
+    });
+
+    test('does not alter longitudes already in [-180, 180]', async () => {
+      const { reverseMock } = makeMocks();
+      const geocoder = require('../src/geocoder');
+      const g = geocoder.coordPreserving('https://nominatim.example/');
+
+      const inRange = { lat: 48.8, lng: 2.35, wrap: () => ({ lat: 48.8, lng: 2.35 }) };
+      await g.reverse(inRange, 1, function() {});
+
+      const calledWith = reverseMock.mock.calls[0][0];
+      expect(calledWith.lng).toBeCloseTo(2.35);
+    });
   });
 });

--- a/test/itinerary_ramp.test.js
+++ b/test/itinerary_ramp.test.js
@@ -51,11 +51,98 @@ describe('applyPatches', () => {
     const fakeRouter = {
       _leftOrRight: function(d) {
         return d.indexOf('left') >= 0 ? 'Left' : 'Right'; // original broken impl
-      }
+      },
+      route: function(waypoints, cb) { cb(null, waypoints); }
     };
     expect(fakeRouter._leftOrRight('straight')).toBe('Right'); // broken before patch
     applyPatches(fakeRouter);
     expect(fakeRouter._leftOrRight('straight')).toBe('straight'); // fixed after patch
   });
+
+  test('applyPatches also installs wrapWaypoints on the router', () => {
+    const { applyPatches } = require('../src/router_patches');
+    const routedWaypoints = [];
+    const fakeRouter = {
+      _leftOrRight: function() {},
+      route: function(waypoints, cb) {
+        routedWaypoints.push(...waypoints);
+        if (cb) cb(null, waypoints);
+      }
+    };
+    applyPatches(fakeRouter);
+
+    const wp = { latLng: { lat: 51.5, lng: -362.8, wrap: function() { return { lat: 51.5, lng: -2.8 }; } }, name: '' };
+    fakeRouter.route([wp], function() {});
+    expect(routedWaypoints[0].latLng.lng).toBeCloseTo(-2.8);
+  });
 });
 
+describe('wrapWaypoints (issues #206, #307)', () => {
+  const { wrapWaypoints } = require('../src/router_patches');
+
+  function makeLatLng(lat, lng) {
+    // Mirrors Leaflet's LatLng.wrap() using the standard modulo formula.
+    var obj = { lat: lat, lng: lng };
+    obj.wrap = function() { return { lat: lat, lng: ((lng + 180) % 360 + 360) % 360 - 180 }; };
+    return obj;
+  }
+
+  test('wraps a waypoint with longitude < -180 before routing', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    router.route([{ latLng: makeLatLng(53.265, -362.806), name: 'A' }], function() {});
+    expect(routed[0].latLng.lng).toBeCloseTo(-2.806);
+  });
+
+  test('wraps a waypoint with longitude > +180 before routing', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    router.route([{ latLng: makeLatLng(39.9, 1556.6), name: 'B' }], function() {});
+    // 1556.6 mod 360 = 116.6
+    expect(routed[0].latLng.lng).toBeCloseTo(116.6);
+  });
+
+  test('leaves coordinates already in [-180, 180] unchanged', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    router.route([{ latLng: makeLatLng(48.8, 2.3), name: 'Paris' }], function() {});
+    expect(routed[0].latLng.lng).toBeCloseTo(2.3);
+  });
+
+  test('handles null waypoints gracefully', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    expect(() => router.route([null, { latLng: makeLatLng(0, 0), name: '' }], function() {})).not.toThrow();
+    expect(routed[1].latLng.lng).toBeCloseTo(0);
+  });
+
+  test('handles waypoints without wrap() gracefully (no Leaflet LatLng)', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    const plainLatLng = { lat: 51.5, lng: -362.8 }; // no .wrap()
+    router.route([{ latLng: plainLatLng, name: 'X' }], function() {});
+    // Without .wrap(), the original (unwrapped) coordinate is passed through
+    expect(routed[0].latLng.lng).toBeCloseTo(-362.8);
+  });
+
+  test('does not mutate the original waypoint object', () => {
+    const routed = [];
+    const router = { route: function(wps, cb) { routed.push(...wps); } };
+    wrapWaypoints(router);
+
+    const original = { latLng: makeLatLng(51.5, -362.8), name: 'orig' };
+    router.route([original], function() {});
+    expect(original.latLng.lng).toBeCloseTo(-362.8); // unchanged
+    expect(routed[0].latLng.lng).toBeCloseTo(-2.8);   // wrapped copy
+  });
+});

--- a/test/itinerary_ramp.test.js
+++ b/test/itinerary_ramp.test.js
@@ -96,6 +96,67 @@ describe('wrapWaypoints (issues #206, #307)', () => {
     expect(routed[0].latLng.lng).toBeCloseTo(-2.806);
   });
 
+  test('re-offsets snapped route.waypoints back to original coordinate space', () => {
+    // LRM calls setWaypoints(route.waypoints) after routing (snap mode),
+    // so snapped coords must stay in the same world copy as the original click.
+    const router = {
+      route: function(wps, cb) {
+        // Simulate OSRM returning a snapped position at the wrapped coordinates
+        const snapped = [{ latLng: { lat: 53.270, lng: -2.800 }, name: '' }];
+        cb(null, [{ waypoints: snapped }]);
+      }
+    };
+    wrapWaypoints(router);
+
+    let receivedRoutes;
+    router.route(
+      [{ latLng: makeLatLng(53.265, -362.806), name: 'A' }],
+      function(err, routes) { receivedRoutes = routes; }
+    );
+    // The snapped waypoint (-2.800) should be re-offset by -360 to match the
+    // original world copy (-362.800).
+    expect(receivedRoutes[0].waypoints[0].latLng.lng).toBeCloseTo(-362.800);
+  });
+
+  test('re-offset snapped waypoint preserves wrap() for further use', () => {
+    const router = {
+      route: function(wps, cb) {
+        const snapped = [{ latLng: { lat: 39.9, lng: 116.603 }, name: '' }];
+        cb(null, [{ waypoints: snapped }]);
+      }
+    };
+    wrapWaypoints(router);
+
+    let receivedRoutes;
+    router.route(
+      [{ latLng: makeLatLng(39.9, 1556.6), name: 'B' }],
+      function(err, routes) { receivedRoutes = routes; }
+    );
+    const reoffset = receivedRoutes[0].waypoints[0].latLng;
+    // Snapped lng 116.603 + offset 1440 = 1556.603
+    expect(reoffset.lng).toBeCloseTo(1556.603);
+    // wrap() on the re-offset latlng should return the in-range value
+    expect(reoffset.wrap().lng).toBeCloseTo(116.603);
+  });
+
+  test('does not re-offset snapped waypoints when original coords are in range', () => {
+    const router = {
+      route: function(wps, cb) {
+        const snapped = [{ latLng: { lat: 48.8, lng: 2.303 }, name: '' }];
+        cb(null, [{ waypoints: snapped }]);
+      }
+    };
+    wrapWaypoints(router);
+
+    let receivedRoutes;
+    router.route(
+      [{ latLng: makeLatLng(48.8, 2.3), name: 'Paris' }],
+      function(err, routes) { receivedRoutes = routes; }
+    );
+    // No offset applied — result stays as-is
+    expect(receivedRoutes[0].waypoints[0].latLng.lng).toBeCloseTo(2.303);
+  });
+
   test('wraps a waypoint with longitude > +180 before routing', () => {
     const routed = [];
     const router = { route: function(wps, cb) { routed.push(...wps); } };

--- a/test/itinerary_ramp.test.js
+++ b/test/itinerary_ramp.test.js
@@ -206,4 +206,50 @@ describe('wrapWaypoints (issues #206, #307)', () => {
     expect(original.latLng.lng).toBeCloseTo(-362.8); // unchanged
     expect(routed[0].latLng.lng).toBeCloseTo(-2.8);   // wrapped copy
   });
+
+  test('re-offsets route.coordinates so the polyline draws in the correct world copy', () => {
+    // OSRM returns in-range coordinates (e.g. lng≈116 for Seattle-area routes).
+    // When the map is panned to lng≈1556 (4 × 360° east), the polyline must be
+    // re-projected by +1440° so LRM draws it at the right viewport position and
+    // fitBounds() does not jump the map to the wrapped world copy.
+    const coords = [
+      { lat: 39.90, lng: 116.39 },
+      { lat: 39.92, lng: 116.45 },
+    ];
+    const router = {
+      route: function(wps, cb) {
+        cb(null, [{
+          waypoints: [{ latLng: { lat: 39.90, lng: 116.39 }, name: '' }],
+          coordinates: coords,
+        }]);
+      }
+    };
+    wrapWaypoints(router);
+
+    let receivedRoutes;
+    router.route(
+      [{ latLng: makeLatLng(39.9, 1556.6), name: 'B' }],
+      function(err, routes) { receivedRoutes = routes; }
+    );
+    // Offset = 1556.6 - 116.6 = 1440 (4 × 360°)
+    expect(receivedRoutes[0].coordinates[0].lng).toBeCloseTo(116.39 + 1440);
+    expect(receivedRoutes[0].coordinates[1].lng).toBeCloseTo(116.45 + 1440);
+  });
+
+  test('does not re-offset route.coordinates when coords are already in range', () => {
+    const coords = [{ lat: 48.8, lng: 2.30 }, { lat: 48.9, lng: 2.35 }];
+    const router = {
+      route: function(wps, cb) {
+        cb(null, [{ waypoints: [{ latLng: { lat: 48.8, lng: 2.30 }, name: '' }], coordinates: coords }]);
+      }
+    };
+    wrapWaypoints(router);
+
+    let receivedRoutes;
+    router.route(
+      [{ latLng: makeLatLng(48.8, 2.3), name: 'Paris' }],
+      function(err, routes) { receivedRoutes = routes; }
+    );
+    expect(receivedRoutes[0].coordinates[0].lng).toBeCloseTo(2.30);
+  });
 });

--- a/test/links.test.js
+++ b/test/links.test.js
@@ -1,8 +1,25 @@
 'use strict';
 
-// Mock leaflet and leaflet-routing-machine so tests run in Node without a DOM
+// Minimal longitude-wrapping helper mirroring Leaflet's LatLng.wrap() behaviour.
+// Used outside jest.mock() factories where it can be referenced freely.
+function wrapLng(v) {
+  return ((v + 180) % 360 + 360) % 360 - 180;
+}
+
+// Mock leaflet and leaflet-routing-machine so tests run in Node without a DOM.
+// The latLng mock includes wrap() so _formatCoord's wrapping logic is exercised.
 jest.mock('leaflet', () => ({
-  latLng: function(lat, lng) { return { lat: lat, lng: lng }; },
+  latLng: function(lat, lng) {
+    var obj = { lat: lat, lng: lng };
+    obj.wrap = function() {
+      // Inline Leaflet's wrapNum(lng, [-180, 180], true) without referencing
+      // out-of-scope variables (jest.mock hoisting restriction).
+      var v = obj.lng;
+      var wrapped = ((v + 180) % 360 + 360) % 360 - 180;
+      return { lat: obj.lat, lng: wrapped };
+    };
+    return obj;
+  },
   Routing: {
     waypoint: function(latlng, name) { return { latLng: latlng, name: name || '' }; }
   }
@@ -79,5 +96,70 @@ describe('links.parse — existing loc= params still work', () => {
     const result = links.parse('loc=52.5,13.4&loc=48.8,2.3&dst=Lyon');
     expect(result.waypoints).toHaveLength(2);
     expect(result.destinationAddress).toBe('Lyon');
+  });
+});
+
+describe('links.format — coordinate wrapping (issues #206, #307)', () => {
+  const L = require('leaflet');
+
+  test('wraps waypoint longitude > 180 when formatting', () => {
+    // Simulates panning east past antimeridian: London scrolled to 360-2.8 = 357.2 degrees
+    const output = links.format({
+      zoom: 9,
+      center: L.latLng(51.5, 13.4),
+      waypoints: [
+        { latLng: L.latLng(53.265, -362.806) },
+        { latLng: L.latLng(51.430, -360.203) }
+      ],
+      language: 'en',
+      alternative: 0
+    });
+    expect(output).toContain('loc=53.265000%2C-2.806000');
+    expect(output).toContain('loc=51.430000%2C-0.203000');
+    expect(output).not.toMatch(/loc=.*-3[56]\d/);
+  });
+
+  test('wraps waypoint longitude > +360 when formatting', () => {
+    // Issue #206: panning east many times produces very large longitudes
+    const output = links.format({
+      zoom: 9,
+      center: L.latLng(39.9, 1556.6),
+      waypoints: [
+        { latLng: L.latLng(39.899, 1556.241) },
+        { latLng: L.latLng(39.918, 1556.612) }
+      ],
+      language: 'en',
+      alternative: 0
+    });
+    // 1556.241 mod 360 = 116.241 (1556.241 - 4*360 = 116.241)
+    expect(output).toContain('loc=39.899000%2C116.241000');
+    expect(output).toContain('loc=39.918000%2C116.612000');
+    expect(output).not.toContain('1556');
+  });
+
+  test('wraps center longitude when formatting', () => {
+    const output = links.format({
+      zoom: 9,
+      center: L.latLng(51.5, -362.8),
+      waypoints: [],
+      language: 'en',
+      alternative: 0
+    });
+    expect(output).toContain('center=51.500000%2C-2.800000');
+    expect(output).not.toContain('-362');
+  });
+
+  test('does not alter coordinates already in [-180, 180]', () => {
+    const output = links.format({
+      zoom: 13,
+      center: L.latLng(52.5, 13.4),
+      waypoints: [
+        { latLng: L.latLng(48.8, 2.3) }
+      ],
+      language: 'en',
+      alternative: 0
+    });
+    expect(output).toContain('center=52.500000%2C13.400000');
+    expect(output).toContain('loc=48.800000%2C2.300000');
   });
 });

--- a/test/links.test.js
+++ b/test/links.test.js
@@ -1,11 +1,5 @@
 'use strict';
 
-// Minimal longitude-wrapping helper mirroring Leaflet's LatLng.wrap() behaviour.
-// Used outside jest.mock() factories where it can be referenced freely.
-function wrapLng(v) {
-  return ((v + 180) % 360 + 360) % 360 - 180;
-}
-
 // Mock leaflet and leaflet-routing-machine so tests run in Node without a DOM.
 // The latLng mock includes wrap() so _formatCoord's wrapping logic is exercised.
 jest.mock('leaflet', () => ({
@@ -102,8 +96,8 @@ describe('links.parse — existing loc= params still work', () => {
 describe('links.format — coordinate wrapping (issues #206, #307)', () => {
   const L = require('leaflet');
 
-  test('wraps waypoint longitude > 180 when formatting', () => {
-    // Simulates panning east past antimeridian: London scrolled to 360-2.8 = 357.2 degrees
+  test('wraps waypoint longitude < -180 when formatting', () => {
+    // Simulates panning west past antimeridian: London scrolled to -360-2.8 = -362.8 degrees
     const output = links.format({
       zoom: 9,
       center: L.latLng(51.5, 13.4),


### PR DESCRIPTION
When the map is panned past the antimeridian, Leaflet reports
longitudes outside the valid [-180, 180] range (e.g. -362.8 or
1556.6).  These out-of-range values were propagated verbatim into:

  1. The browser URL bar (loc= and center= params in links.js).
  2. The routing request sent to the OSRM backend, causing a 400 error.
  3. The Nominatim reverse-geocode request made when a marker is placed.

Fix by calling Leaflet's LatLng.wrap() in each of these three places:

  * src/links.js  _formatCoord() — wraps before building the URL string.
  * src/router_patches.js  wrapWaypoints() — monkey-patches router.route()
    to wrap every waypoint's latLng before the request leaves the client;
    called automatically by applyPatches().
  * src/geocoder.js  doReverse() — wraps the incoming latlng at function
    entry so both the Nominatim fetch URL and the nominatim.reverse() call
    receive valid coordinates.

All three helpers are guarded with typeof latLng.wrap === 'function' so
the code degrades gracefully in environments where the mock omits wrap().

Tests added for all three code paths:
  * test/links.test.js — formatLink wraps lng < -180, lng > 360, center.
  * test/itinerary_ramp.test.js — wrapWaypoints wraps, is no-op in range,
    handles null waypoints, does not mutate originals; applyPatches installs it.
  * test/geocoder.test.js — reverse() passes wrapped coordinates to
    nominatim.reverse() for lng < -180 and lng > +180.

fixes #206 & #307

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
