### PR TITLE
feat: zoom to z14 on locate when no route exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -598,3 +598,7 @@ L.control.locate({
   showPopup: false,
   locateOptions: {}
 }).addTo(map);
+
+// Zoom to z14 when the user's location is found, but only if no route is computed.
+var createLocationFoundHandler = require('./location_handler');
+map.on('locationfound', createLocationFoundHandler(map, lrmControl));

--- a/src/location_handler.js
+++ b/src/location_handler.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var L = require('leaflet');
+
+module.exports = function createLocationFoundHandler(map, lrmControl) {
+  return function(e) {
+    try {
+      var latlng = e && e.latlng ? e.latlng : null;
+      if (!latlng) return;
+      var hasRoute = false;
+      if (lrmControl) {
+        if (Array.isArray(lrmControl._routes) && lrmControl._routes.length > 0) hasRoute = true;
+        if (typeof lrmControl._selectedRoute !== 'undefined' && lrmControl._selectedRoute !== null) hasRoute = true;
+      }
+      if (!hasRoute) {
+        map.setView(latlng, 14);
+      }
+    } catch (err) {
+      console.error('Error in locationfound handler:', err);
+    }
+  };
+};

--- a/src/location_handler.js
+++ b/src/location_handler.js
@@ -5,11 +5,13 @@ module.exports = function createLocationFoundHandler(map, lrmControl) {
     try {
       var latlng = e && e.latlng ? e.latlng : null;
       if (!latlng) return;
+      // Determine whether a route is present. Align with src/state.js which
+      // treats a non-empty _routes array as the source of truth.
       var hasRoute = false;
-      if (lrmControl) {
-        if (Array.isArray(lrmControl._routes) && lrmControl._routes.length > 0) hasRoute = true;
-        if (typeof lrmControl._selectedRoute !== 'undefined' && lrmControl._selectedRoute !== null) hasRoute = true;
+      if (lrmControl && Array.isArray(lrmControl._routes) && lrmControl._routes.length > 0) {
+        hasRoute = true;
       }
+
       if (!hasRoute) {
         map.setView(latlng, 14);
       }

--- a/src/location_handler.js
+++ b/src/location_handler.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var L = require('leaflet');
-
 module.exports = function createLocationFoundHandler(map, lrmControl) {
   return function(e) {
     try {

--- a/test/locationfound.test.js
+++ b/test/locationfound.test.js
@@ -26,3 +26,18 @@ test('locationfound does not change zoom when route exists', () => {
   map.fire('locationfound', {latlng: L.latLng(51, 9)});
   expect(map.getZoom()).toBe(11);
 });
+
+test('locationfound fires on repeated activations (turn off/on)', () => {
+  document.body.innerHTML = '<div id="map" style="width:800px;height:600px"></div>';
+  var map = L.map('map', {center: [0,0], zoom: 12});
+  var lrmControl = {_routes: [], _selectedRoute: undefined};
+  var handler = createHandler(map, lrmControl);
+  map.on('locationfound', handler);
+  // first activation
+  map.fire('locationfound', {latlng: L.latLng(52, 10)});
+  expect(map.getZoom()).toBe(14);
+  // simulate user turning off and on again by firing another locationfound
+  map.setView([0,0], 10);
+  map.fire('locationfound', {latlng: L.latLng(53, 11)});
+  expect(map.getZoom()).toBe(14);
+});

--- a/test/locationfound.test.js
+++ b/test/locationfound.test.js
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment jsdom
+ */
+'use strict';
+
+var L = require('leaflet');
+var createHandler = require('../src/location_handler');
+
+test('locationfound zooms to z14 when no route exists', () => {
+  document.body.innerHTML = '<div id="map" style="width:800px;height:600px"></div>';
+  var map = L.map('map', {center: [0,0], zoom: 10});
+  var lrmControl = {_routes: [], _selectedRoute: undefined};
+  var handler = createHandler(map, lrmControl);
+  map.on('locationfound', handler);
+  map.fire('locationfound', {latlng: L.latLng(50, 8)});
+  expect(map.getZoom()).toBe(14);
+  expect(map.getCenter().lat).toBeCloseTo(50, 5);
+});
+
+test('locationfound does not change zoom when route exists', () => {
+  document.body.innerHTML = '<div id="map" style="width:800px;height:600px"></div>';
+  var map = L.map('map', {center: [0,0], zoom: 11});
+  var lrmControl = {_routes: [{}, {}], _selectedRoute: 0};
+  var handler = createHandler(map, lrmControl);
+  map.on('locationfound', handler);
+  map.fire('locationfound', {latlng: L.latLng(51, 9)});
+  expect(map.getZoom()).toBe(11);
+});


### PR DESCRIPTION
Add locationfound handler and tests to zoom to level 14 when locating the user, but only if no route is present.