### PR TITLE
chore: rename dependabot workflow to weekly-deps-update to avoid confusion

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/weekly-deps-update.yml
+++ b/.github/workflows/weekly-deps-update.yml
@@ -1,4 +1,4 @@
-name: Dependabot Updates
+name: Weekly dependency update
 
 on:
   schedule:
@@ -9,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  weekly-deps-update:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Renames .github/workflows/dependabot.yml to .github/workflows/weekly-deps-update.yml to avoid confusion with Dependabot config. Keeps .github/dependabot.yml for Dependabot.