### PR TITLE
fix(dragging): abort previous route requests during dragging #394

### DIFF
--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -24,6 +24,10 @@ function leftOrRight(d) {
 // We re-offset the snapped latlngs back by the same ±n×360° that was applied
 // during wrapping, keeping markers in the correct viewport position.
 function wrapWaypoints(router) {
+  // Make this idempotent: avoid double-patching the same router instance.
+  if (router._wrapWaypointsPatched) return;
+  router._wrapWaypointsPatched = true;
+
   var origRoute = router.route.bind(router);
   // Track last request so we can abort or ignore out-of-order responses
   router._lastRouteRequestId = router._lastRouteRequestId || 0;

--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -50,7 +50,11 @@ function wrapWaypoints(router) {
     var requestId = (router._lastRouteRequestId || 0) + 1;
     router._lastRouteRequestId = requestId;
     if (router._lastXhr && typeof router._lastXhr.abort === 'function') {
-      try { router._lastXhr.abort(); } catch (e) { /* ignore abort errors */ }
+      try {
+        router._lastXhr.abort();
+      } catch (e) {
+        /* ignore abort errors */
+      }
     }
 
     var wrappedCallback = function(err, routes) {

--- a/src/router_patches.js
+++ b/src/router_patches.js
@@ -25,6 +25,10 @@ function leftOrRight(d) {
 // during wrapping, keeping markers in the correct viewport position.
 function wrapWaypoints(router) {
   var origRoute = router.route.bind(router);
+  // Track last request so we can abort or ignore out-of-order responses
+  router._lastRouteRequestId = router._lastRouteRequestId || 0;
+  router._lastXhr = router._lastXhr || null;
+
   router.route = function(waypoints, callback, context, options) {
     var wrapped = (waypoints || []).map(function(wp) {
       if (!wp || !wp.latLng || typeof wp.latLng.wrap !== 'function') return wp;
@@ -41,7 +45,18 @@ function wrapWaypoints(router) {
       return acc !== 0 ? acc : o;
     }, 0);
 
+    // Bump request id and abort any previous in-flight request to avoid
+    // out-of-order responses interfering with the latest drag action.
+    var requestId = (router._lastRouteRequestId || 0) + 1;
+    router._lastRouteRequestId = requestId;
+    if (router._lastXhr && typeof router._lastXhr.abort === 'function') {
+      try { router._lastXhr.abort(); } catch (e) { /* ignore abort errors */ }
+    }
+
     var wrappedCallback = function(err, routes) {
+      // Ignore responses from older/aborted requests
+      if (router._lastRouteRequestId !== requestId) return;
+
       if (!err && routes) {
         routes.forEach(function(route) {
           if (route && route.waypoints) {
@@ -77,7 +92,9 @@ function wrapWaypoints(router) {
       if (typeof callback === 'function') callback.apply(context || callback, arguments);
     };
 
-    return origRoute(wrapped, wrappedCallback, context, options);
+    var xhr = origRoute(wrapped, wrappedCallback, context, options);
+    router._lastXhr = xhr;
+    return xhr;
   };
 }
 

--- a/test/router_patches.test.js
+++ b/test/router_patches.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const rp = require('../src/router_patches');
+
+describe('router_patches', () => {
+  test('leftOrRight preserves non-directional modifiers', () => {
+    expect(rp.leftOrRight('on ramp straight')).toBe('on ramp straight');
+    expect(rp.leftOrRight('keep left then turn')).toBe('Left');
+    expect(rp.leftOrRight('turn right ahead')).toBe('Right');
+  });
+
+  test('wrapWaypoints aborts previous XHR and ignores older responses', (done) => {
+    // Fake router.route that returns an xhr-like object and calls the callback after a delay
+    const router = {
+      route: function(waypoints, callback /*, context, options */) {
+        const delay = (waypoints && waypoints[0] && waypoints[0].delay) || 10;
+        const xhr = { aborted: false, abort() { this.aborted = true; } };
+        setTimeout(() => {
+          // Simulate a response: include waypoints in the shape expected by wrapWaypoints
+          const resp = [{ waypoints: (waypoints || []).map(wp => ({ latLng: wp.latLng })) }];
+          try {
+            callback(null, resp);
+          } catch (e) {
+            // ignore
+          }
+        }, delay);
+        return xhr;
+      }
+    };
+
+    rp.wrapWaypoints(router);
+
+    const cb1 = jest.fn();
+    const cb2 = jest.fn(() => {
+      // allow time for the earlier (slower) response to fire if it wasn't ignored
+      setTimeout(() => {
+        try {
+          expect(cb1).not.toHaveBeenCalled();
+          expect(cb2).toHaveBeenCalled();
+          done();
+        } catch (err) {
+          done(err);
+        }
+      }, 40);
+    });
+
+    const wp1 = [{ latLng: { lat: 0, lng: 0, wrap() { return { lat: 0, lng: 0 }; } }, delay: 80 }];
+    const wp2 = [{ latLng: { lat: 1, lng: 1, wrap() { return { lat: 1, lng: 1 }; } }, delay: 10 }];
+
+    const xhr1 = router.route(wp1, cb1);
+    // Second route should abort the first xhr synchronously within the wrapper
+    const xhr2 = router.route(wp2, cb2);
+
+    // xhr1 should expose an abort function
+    expect(xhr1 && typeof xhr1.abort === 'function').toBe(true);
+    // abort should have been called synchronously when the second route was invoked
+    if (typeof xhr1.aborted !== 'undefined') {
+      expect(xhr1.aborted).toBe(true);
+    }
+
+  }, 1000);
+
+});

--- a/test/router_patches.test.js
+++ b/test/router_patches.test.js
@@ -49,7 +49,7 @@ describe('router_patches', () => {
 
     const xhr1 = router.route(wp1, cb1);
     // Second route should abort the first xhr synchronously within the wrapper
-    const xhr2 = router.route(wp2, cb2);
+    router.route(wp2, cb2);
 
     // xhr1 should expose an abort function
     expect(xhr1 && typeof xhr1.abort === 'function').toBe(true);


### PR DESCRIPTION
Closes #394. Abort previous in-flight route requests during dragging to avoid out-of-order responses that overwrite newer routes. Adds unit tests (test/router_patches.test.js).